### PR TITLE
Add multi-monitor capture and timeline support

### DIFF
--- a/App/AppCoordinator.swift
+++ b/App/AppCoordinator.swift
@@ -1798,14 +1798,18 @@ public actor AppCoordinator {
             }
 
             do {
-                let resolutionKey = "\(frame.width)x\(frame.height)"
+                let resolutionKey = Self.videoWriterKey(for: frame)
                 var writerState: VideoWriterState
 
                 if var existingState = writersByResolution[resolutionKey] {
                     if existingState.frameCount >= maxFramesPerSegment {
                         try await finalizeWriter(&existingState, processingQueue: await services.processingQueue)
                         writersByResolution.removeValue(forKey: resolutionKey)
-                        writerState = try await createNewWriterState(width: frame.width, height: frame.height)
+                        writerState = try await createNewWriterState(
+                            width: frame.width,
+                            height: frame.height,
+                            displayStableID: frame.metadata.displayStableID
+                        )
                         writersByResolution[resolutionKey] = writerState
                     } else {
                         writerState = existingState
@@ -1813,12 +1817,17 @@ public actor AppCoordinator {
                 } else {
                     if let unfinalised = try await services.database.getUnfinalisedVideoByResolution(
                         width: frame.width,
-                        height: frame.height
+                        height: frame.height,
+                        displayStableID: frame.metadata.displayStableID
                     ), try await shouldResumeUnfinalisedVideo(unfinalised) {
                         Log.info("Resuming unfinalised video \(unfinalised.id) for resolution \(resolutionKey)", category: .app)
                         writerState = try await resumeWriterState(from: unfinalised)
                     } else {
-                        writerState = try await createNewWriterState(width: frame.width, height: frame.height)
+                        writerState = try await createNewWriterState(
+                            width: frame.width,
+                            height: frame.height,
+                            displayStableID: frame.metadata.displayStableID
+                        )
                     }
                     writersByResolution[resolutionKey] = writerState
                 }
@@ -2048,7 +2057,7 @@ public actor AppCoordinator {
                 // File write failures mean the active writer is no longer trustworthy.
                 // Stop recording instead of pretending capture is still healthy.
                 if case .fileWriteFailed = error {
-                    let resolutionKey = "\(frame.width)x\(frame.height)"
+                    let resolutionKey = Self.videoWriterKey(for: frame)
                     if let brokenWriter = writersByResolution[resolutionKey] {
                         let summary =
                             "File write failed for videoDBID=\(brokenWriter.videoDBID) at \(resolutionKey). " +
@@ -2451,7 +2460,23 @@ public actor AppCoordinator {
         return outputData as Data
     }
 
-    private func createNewWriterState(width: Int, height: Int) async throws -> VideoWriterState {
+    private static func videoWriterKey(for frame: CapturedFrame) -> String {
+        let displayKey: String
+        if let displayStableID = frame.metadata.displayStableID,
+           !displayStableID.isEmpty {
+            displayKey = displayStableID
+        } else {
+            displayKey = "runtime-display:\(frame.metadata.displayID)"
+        }
+
+        return "\(displayKey)|\(frame.width)x\(frame.height)"
+    }
+
+    private func createNewWriterState(
+        width: Int,
+        height: Int,
+        displayStableID: String?
+    ) async throws -> VideoWriterState {
         let writer = try await services.storage.createSegmentWriter()
         let relativePath = await writer.relativePath
 
@@ -2463,10 +2488,11 @@ public actor AppCoordinator {
             fileSizeBytes: 0,
             relativePath: relativePath,
             width: width,
-            height: height
+            height: height,
+            displayStableID: displayStableID
         )
         let videoDBID = try await services.database.insertVideoSegment(placeholderSegment)
-        Log.debug("New video segment created with DB ID: \(videoDBID) for resolution \(width)x\(height)", category: .app)
+        Log.debug("New video segment created with DB ID: \(videoDBID) for resolution \(width)x\(height) display=\(displayStableID ?? "legacy")", category: .app)
 
         return VideoWriterState(
             writer: writer,
@@ -2501,7 +2527,8 @@ public actor AppCoordinator {
             fileSizeBytes: 0,
             relativePath: relativePath,
             width: unfinalised.width,
-            height: unfinalised.height
+            height: unfinalised.height,
+            displayStableID: unfinalised.displayStableID
         )
         let videoDBID = try await services.database.insertVideoSegment(placeholderSegment)
 
@@ -3315,90 +3342,182 @@ public actor AppCoordinator {
     /// Get frames in a time range
     /// Seamlessly blends data from all sources via DataAdapter
     public func getFrames(from startDate: Date, to endDate: Date, limit: Int = 500, filters: FilterCriteria? = nil) async throws -> [FrameReference] {
+        let connectedDisplayStableIDs = await connectedDisplayStableIDsForVisibilityFilter()
+        let queryLimit = displayVisibilityQueryLimit(limit, connectedDisplayStableIDs: connectedDisplayStableIDs)
         guard let adapter = await services.dataAdapter else {
             // Fallback to database if adapter not available
-            return try await services.database.getFrames(from: startDate, to: endDate, limit: limit)
+            let frames = try await services.database.getFrames(from: startDate, to: endDate, limit: queryLimit)
+            return filterVisibleConnectedDisplayFrames(frames, limit: limit, connectedDisplayStableIDs: connectedDisplayStableIDs)
         }
 
-        return try await adapter.getFrames(from: startDate, to: endDate, limit: limit, filters: filters)
+        let frames = try await adapter.getFrames(from: startDate, to: endDate, limit: queryLimit, filters: filters)
+        return filterVisibleConnectedDisplayFrames(frames, limit: limit, connectedDisplayStableIDs: connectedDisplayStableIDs)
     }
 
     /// Get frames with video info in a time range (optimized - single query with JOINs)
     /// This is the preferred method for timeline views to avoid N+1 queries
     public func getFramesWithVideoInfo(from startDate: Date, to endDate: Date, limit: Int = 500, filters: FilterCriteria? = nil) async throws -> [FrameWithVideoInfo] {
+        let connectedDisplayStableIDs = await connectedDisplayStableIDsForVisibilityFilter()
+        let queryLimit = displayVisibilityQueryLimit(limit, connectedDisplayStableIDs: connectedDisplayStableIDs)
         guard let adapter = await services.dataAdapter else {
             // Fallback to database (no video info for native)
-            let frames = try await services.database.getFrames(from: startDate, to: endDate, limit: limit)
-            return frames.map { FrameWithVideoInfo(frame: $0, videoInfo: nil) }
+            let frames = try await services.database.getFrames(from: startDate, to: endDate, limit: queryLimit)
+            return filterVisibleConnectedDisplayFrames(frames, limit: limit, connectedDisplayStableIDs: connectedDisplayStableIDs)
+                .map { FrameWithVideoInfo(frame: $0, videoInfo: nil) }
         }
 
-        return try await adapter.getFramesWithVideoInfo(from: startDate, to: endDate, limit: limit, filters: filters)
+        let frames = try await adapter.getFramesWithVideoInfo(from: startDate, to: endDate, limit: queryLimit, filters: filters)
+        return filterVisibleConnectedDisplayFrameInfo(frames, limit: limit, connectedDisplayStableIDs: connectedDisplayStableIDs)
     }
 
     /// Get the most recent frames across all sources
     /// Returns frames sorted by timestamp descending (newest first)
     public func getMostRecentFrames(limit: Int = 500, filters: FilterCriteria? = nil) async throws -> [FrameReference] {
+        let connectedDisplayStableIDs = await connectedDisplayStableIDsForVisibilityFilter()
+        let queryLimit = displayVisibilityQueryLimit(limit, connectedDisplayStableIDs: connectedDisplayStableIDs)
         guard let adapter = await services.dataAdapter else {
             // Fallback to database
-            return try await services.database.getMostRecentFrames(limit: limit)
+            let frames = try await services.database.getMostRecentFrames(limit: queryLimit)
+            return filterVisibleConnectedDisplayFrames(frames, limit: limit, connectedDisplayStableIDs: connectedDisplayStableIDs)
         }
 
-        return try await adapter.getMostRecentFrames(limit: limit, filters: filters)
+        let frames = try await adapter.getMostRecentFrames(limit: queryLimit, filters: filters)
+        return filterVisibleConnectedDisplayFrames(frames, limit: limit, connectedDisplayStableIDs: connectedDisplayStableIDs)
     }
 
     /// Get the most recent frames with video info (optimized - single query with JOINs)
     public func getMostRecentFramesWithVideoInfo(limit: Int = 500, filters: FilterCriteria? = nil) async throws -> [FrameWithVideoInfo] {
+        let connectedDisplayStableIDs = await connectedDisplayStableIDsForVisibilityFilter()
+        let queryLimit = displayVisibilityQueryLimit(limit, connectedDisplayStableIDs: connectedDisplayStableIDs)
         guard let adapter = await services.dataAdapter else {
             // Fallback to database (no video info for native)
-            let frames = try await services.database.getMostRecentFrames(limit: limit)
-            return frames.map { FrameWithVideoInfo(frame: $0, videoInfo: nil) }
+            let frames = try await services.database.getMostRecentFrames(limit: queryLimit)
+            return filterVisibleConnectedDisplayFrames(frames, limit: limit, connectedDisplayStableIDs: connectedDisplayStableIDs)
+                .map { FrameWithVideoInfo(frame: $0, videoInfo: nil) }
         }
 
-        return try await adapter.getMostRecentFramesWithVideoInfo(limit: limit, filters: filters)
+        let frames = try await adapter.getMostRecentFramesWithVideoInfo(limit: queryLimit, filters: filters)
+        return filterVisibleConnectedDisplayFrameInfo(frames, limit: limit, connectedDisplayStableIDs: connectedDisplayStableIDs)
     }
 
     /// Get frames before a timestamp (for infinite scroll - loading older frames)
     /// Returns frames sorted by timestamp descending (newest first of the older batch)
     public func getFramesBefore(timestamp: Date, limit: Int = 300, filters: FilterCriteria? = nil) async throws -> [FrameReference] {
+        let connectedDisplayStableIDs = await connectedDisplayStableIDsForVisibilityFilter()
+        let queryLimit = displayVisibilityQueryLimit(limit, connectedDisplayStableIDs: connectedDisplayStableIDs)
         guard let adapter = await services.dataAdapter else {
             // Fallback to database
-            return try await services.database.getFramesBefore(timestamp: timestamp, limit: limit)
+            let frames = try await services.database.getFramesBefore(timestamp: timestamp, limit: queryLimit)
+            return filterVisibleConnectedDisplayFrames(frames, limit: limit, connectedDisplayStableIDs: connectedDisplayStableIDs)
         }
 
-        return try await adapter.getFramesBefore(timestamp: timestamp, limit: limit, filters: filters)
+        let frames = try await adapter.getFramesBefore(timestamp: timestamp, limit: queryLimit, filters: filters)
+        return filterVisibleConnectedDisplayFrames(frames, limit: limit, connectedDisplayStableIDs: connectedDisplayStableIDs)
     }
 
     /// Get frames with video info before a timestamp (optimized - single query with JOINs)
     public func getFramesWithVideoInfoBefore(timestamp: Date, limit: Int = 300, filters: FilterCriteria? = nil) async throws -> [FrameWithVideoInfo] {
+        let connectedDisplayStableIDs = await connectedDisplayStableIDsForVisibilityFilter()
+        let queryLimit = displayVisibilityQueryLimit(limit, connectedDisplayStableIDs: connectedDisplayStableIDs)
         guard let adapter = await services.dataAdapter else {
             // Fallback to database (no video info for native)
-            let frames = try await services.database.getFramesBefore(timestamp: timestamp, limit: limit)
-            return frames.map { FrameWithVideoInfo(frame: $0, videoInfo: nil) }
+            let frames = try await services.database.getFramesBefore(timestamp: timestamp, limit: queryLimit)
+            return filterVisibleConnectedDisplayFrames(frames, limit: limit, connectedDisplayStableIDs: connectedDisplayStableIDs)
+                .map { FrameWithVideoInfo(frame: $0, videoInfo: nil) }
         }
 
-        return try await adapter.getFramesWithVideoInfoBefore(timestamp: timestamp, limit: limit, filters: filters)
+        let frames = try await adapter.getFramesWithVideoInfoBefore(timestamp: timestamp, limit: queryLimit, filters: filters)
+        return filterVisibleConnectedDisplayFrameInfo(frames, limit: limit, connectedDisplayStableIDs: connectedDisplayStableIDs)
     }
 
     /// Get frames after a timestamp (for infinite scroll - loading newer frames)
     /// Returns frames sorted by timestamp ascending (oldest first of the newer batch)
     public func getFramesAfter(timestamp: Date, limit: Int = 300, filters: FilterCriteria? = nil) async throws -> [FrameReference] {
+        let connectedDisplayStableIDs = await connectedDisplayStableIDsForVisibilityFilter()
+        let queryLimit = displayVisibilityQueryLimit(limit, connectedDisplayStableIDs: connectedDisplayStableIDs)
         guard let adapter = await services.dataAdapter else {
             // Fallback to database
-            return try await services.database.getFramesAfter(timestamp: timestamp, limit: limit)
+            let frames = try await services.database.getFramesAfter(timestamp: timestamp, limit: queryLimit)
+            return filterVisibleConnectedDisplayFrames(frames, limit: limit, connectedDisplayStableIDs: connectedDisplayStableIDs)
         }
 
-        return try await adapter.getFramesAfter(timestamp: timestamp, limit: limit, filters: filters)
+        let frames = try await adapter.getFramesAfter(timestamp: timestamp, limit: queryLimit, filters: filters)
+        return filterVisibleConnectedDisplayFrames(frames, limit: limit, connectedDisplayStableIDs: connectedDisplayStableIDs)
     }
 
     /// Get frames with video info after a timestamp (optimized - single query with JOINs)
     public func getFramesWithVideoInfoAfter(timestamp: Date, limit: Int = 300, filters: FilterCriteria? = nil) async throws -> [FrameWithVideoInfo] {
+        let connectedDisplayStableIDs = await connectedDisplayStableIDsForVisibilityFilter()
+        let queryLimit = displayVisibilityQueryLimit(limit, connectedDisplayStableIDs: connectedDisplayStableIDs)
         guard let adapter = await services.dataAdapter else {
             // Fallback to database (no video info for native)
-            let frames = try await services.database.getFramesAfter(timestamp: timestamp, limit: limit)
-            return frames.map { FrameWithVideoInfo(frame: $0, videoInfo: nil) }
+            let frames = try await services.database.getFramesAfter(timestamp: timestamp, limit: queryLimit)
+            return filterVisibleConnectedDisplayFrames(frames, limit: limit, connectedDisplayStableIDs: connectedDisplayStableIDs)
+                .map { FrameWithVideoInfo(frame: $0, videoInfo: nil) }
         }
 
-        return try await adapter.getFramesWithVideoInfoAfter(timestamp: timestamp, limit: limit, filters: filters)
+        let frames = try await adapter.getFramesWithVideoInfoAfter(timestamp: timestamp, limit: queryLimit, filters: filters)
+        return filterVisibleConnectedDisplayFrameInfo(frames, limit: limit, connectedDisplayStableIDs: connectedDisplayStableIDs)
+    }
+
+    private func connectedDisplayStableIDsForVisibilityFilter() async -> Set<String>? {
+        do {
+            let displays = try await services.capture.getAvailableDisplays()
+            let stableIDs = displays.compactMap(\.stableID).filter { !$0.isEmpty }
+            return stableIDs.isEmpty ? nil : Set(stableIDs)
+        } catch {
+            Log.warning(
+                "[AppCoordinator] Failed to enumerate connected displays for timeline filtering: \(error.localizedDescription)",
+                category: .app
+            )
+            return nil
+        }
+    }
+
+    private func filterVisibleConnectedDisplayFrameInfo(
+        _ frames: [FrameWithVideoInfo],
+        limit: Int,
+        connectedDisplayStableIDs: Set<String>?
+    ) -> [FrameWithVideoInfo] {
+        Array(
+            frames
+                .filter { isFrameVisibleForConnectedDisplays($0.frame, connectedDisplayStableIDs: connectedDisplayStableIDs) }
+                .prefix(max(0, limit))
+        )
+    }
+
+    private func filterVisibleConnectedDisplayFrames(
+        _ frames: [FrameReference],
+        limit: Int,
+        connectedDisplayStableIDs: Set<String>?
+    ) -> [FrameReference] {
+        Array(
+            frames
+                .filter { isFrameVisibleForConnectedDisplays($0, connectedDisplayStableIDs: connectedDisplayStableIDs) }
+                .prefix(max(0, limit))
+        )
+    }
+
+    private func displayVisibilityQueryLimit(
+        _ limit: Int,
+        connectedDisplayStableIDs: Set<String>?
+    ) -> Int {
+        guard connectedDisplayStableIDs != nil else { return limit }
+        let normalizedLimit = max(0, limit)
+        guard normalizedLimit > 0 else { return 0 }
+        return min(max(normalizedLimit, normalizedLimit * 4), 2_000)
+    }
+
+    private func isFrameVisibleForConnectedDisplays(
+        _ frame: FrameReference,
+        connectedDisplayStableIDs: Set<String>?
+    ) -> Bool {
+        guard let connectedDisplayStableIDs else { return true }
+        guard let displayStableID = frame.metadata.displayStableID,
+              !displayStableID.isEmpty else {
+            return true
+        }
+        return connectedDisplayStableIDs.contains(displayStableID)
     }
 
     /// Get the timestamp of the most recent frame across all sources

--- a/App/DataAdapter.swift
+++ b/App/DataAdapter.swift
@@ -1582,6 +1582,9 @@ public actor DataAdapter {
         let mousePositionColumn: String
         let scrollPositionColumn: String
         let videoCurrentTimeColumn: String
+        let displayIDColumn: String
+        let displayStableIDColumn: String
+        let displayNameColumn: String
     }
 
     private static func frameWithVideoProjection(
@@ -1596,7 +1599,10 @@ public actor DataAdapter {
                 captureTriggerColumn: "NULL as captureTrigger",
                 mousePositionColumn: "NULL",
                 scrollPositionColumn: "NULL",
-                videoCurrentTimeColumn: "NULL"
+                videoCurrentTimeColumn: "NULL",
+                displayIDColumn: "0 as displayId",
+                displayStableIDColumn: "NULL as displayStableId",
+                displayNameColumn: "NULL as displayName"
             )
         }
 
@@ -1607,7 +1613,10 @@ public actor DataAdapter {
             captureTriggerColumn: "\(tableAlias).capture_trigger",
             mousePositionColumn: "\(tableAlias).mousePosition",
             scrollPositionColumn: "\(tableAlias).scrollPosition",
-            videoCurrentTimeColumn: "\(tableAlias).videoCurrentTime"
+            videoCurrentTimeColumn: "\(tableAlias).videoCurrentTime",
+            displayIDColumn: "\(tableAlias).displayId",
+            displayStableIDColumn: "\(tableAlias).displayStableId",
+            displayNameColumn: "\(tableAlias).displayName"
         )
     }
 
@@ -1620,7 +1629,10 @@ public actor DataAdapter {
                 captureTriggerColumn: "NULL as captureTrigger",
                 mousePositionColumn: "NULL as mousePosition",
                 scrollPositionColumn: "NULL as scrollPosition",
-                videoCurrentTimeColumn: "NULL as videoCurrentTime"
+                videoCurrentTimeColumn: "NULL as videoCurrentTime",
+                displayIDColumn: "0 as displayId",
+                displayStableIDColumn: "NULL as displayStableId",
+                displayNameColumn: "NULL as displayName"
             )
         }
 
@@ -1631,7 +1643,10 @@ public actor DataAdapter {
             captureTriggerColumn: "capture_trigger",
             mousePositionColumn: "mousePosition",
             scrollPositionColumn: "scrollPosition",
-            videoCurrentTimeColumn: "videoCurrentTime"
+            videoCurrentTimeColumn: "videoCurrentTime",
+            displayIDColumn: "displayId",
+            displayStableIDColumn: "displayStableId",
+            displayNameColumn: "displayName"
         )
     }
 
@@ -1641,11 +1656,12 @@ public actor DataAdapter {
         videoAlias: String
     ) -> String {
         if source == .rewind {
-            return "\(videoAlias).path, \(videoAlias).frameRate, \(videoAlias).width, \(videoAlias).height, 0 as videoProcessingState, NULL as videoFileSize, NULL as videoFrameCount, NULL as videoReencodedAt"
+            return "\(videoAlias).path, \(videoAlias).frameRate, \(videoAlias).width, \(videoAlias).height, NULL as videoDisplayStableId, 0 as videoProcessingState, NULL as videoFileSize, NULL as videoFrameCount, NULL as videoReencodedAt"
         }
 
         return """
             \(videoAlias).path, \(videoAlias).frameRate, \(videoAlias).width, \(videoAlias).height,
+            \(videoAlias).displayStableId as videoDisplayStableId,
             \(videoAlias).processingState as videoProcessingState, \(videoAlias).fileSize as videoFileSize, \(videoAlias).frameCount as videoFrameCount,
             (SELECT MAX(fr.rewrittenAt) FROM frame fr WHERE fr.videoId = \(frameAlias).videoId) as videoReencodedAt
             """
@@ -1677,6 +1693,17 @@ public actor DataAdapter {
         if let apps = filters?.selectedApps, !apps.isEmpty {
             let filterMode = filters?.appFilterMode ?? .include
             whereClauses.append(Self.buildAppFilterClause(apps: apps, mode: filterMode))
+        }
+
+        let displayStableIDs = filters?.selectedDisplayStableIDs?.sorted() ?? []
+        let displayStableIDsToBind = config.source == .rewind ? [] : displayStableIDs
+        if !displayStableIDs.isEmpty {
+            if config.source == .rewind {
+                whereClauses.append("0")
+            } else {
+                let placeholders = displayStableIDs.map { _ in "?" }.joined(separator: ", ")
+                whereClauses.append("f.displayStableId IN (\(placeholders))")
+            }
         }
 
         // Tag filter - need to join with segment_tag
@@ -1711,6 +1738,9 @@ public actor DataAdapter {
                 \(projection.mousePositionColumn),
                 \(projection.scrollPositionColumn),
                 \(projection.videoCurrentTimeColumn),
+                \(projection.displayIDColumn),
+                \(projection.displayStableIDColumn),
+                \(projection.displayNameColumn),
                 \(Self.videoInfoProjection(source: config.source, frameAlias: "f", videoAlias: "v"))
             FROM frame f
             LEFT JOIN segment s ON f.segmentId = s.id
@@ -1734,6 +1764,11 @@ public actor DataAdapter {
             }
             bindIndex += apps.count
         }
+
+        for (index, displayStableID) in displayStableIDsToBind.enumerated() {
+            sqlite3_bind_text(statement, Int32(bindIndex + index), (displayStableID as NSString).utf8String, -1, nil)
+        }
+        bindIndex += displayStableIDsToBind.count
 
         // Bind tag IDs
         if let tags = filters?.selectedTags, !tags.isEmpty {
@@ -1787,9 +1822,10 @@ public actor DataAdapter {
             SELECT f.id, f.createdAt, f.segmentId, f.videoId, f.videoFrameIndex, \(projection.encodedAtColumn), \(projection.processingStatusColumn), \(projection.redactionReasonColumn),
                    \(projection.captureTriggerColumn),
                    s.bundleID, s.windowName, s.browserUrl, \(projection.mousePositionColumn), \(projection.scrollPositionColumn), \(projection.videoCurrentTimeColumn),
+                   \(projection.displayIDColumn), \(projection.displayStableIDColumn), \(projection.displayNameColumn),
                    \(Self.videoInfoProjection(source: config.source, frameAlias: "f", videoAlias: "v"))
             FROM (
-                SELECT id, createdAt, segmentId, videoId, videoFrameIndex, \(subqueryProjection.encodedAtColumn), \(subqueryProjection.processingStatusColumn), \(subqueryProjection.redactionReasonColumn), \(subqueryProjection.captureTriggerColumn), \(subqueryProjection.mousePositionColumn), \(subqueryProjection.scrollPositionColumn), \(subqueryProjection.videoCurrentTimeColumn)
+                SELECT id, createdAt, segmentId, videoId, videoFrameIndex, \(subqueryProjection.encodedAtColumn), \(subqueryProjection.processingStatusColumn), \(subqueryProjection.redactionReasonColumn), \(subqueryProjection.captureTriggerColumn), \(subqueryProjection.mousePositionColumn), \(subqueryProjection.scrollPositionColumn), \(subqueryProjection.videoCurrentTimeColumn), \(subqueryProjection.displayIDColumn), \(subqueryProjection.displayStableIDColumn), \(subqueryProjection.displayNameColumn)
                 FROM frame
                 \(boundaryWhereClause)
                 ORDER BY createdAt DESC
@@ -1870,6 +1906,7 @@ public actor DataAdapter {
             SELECT f.id, f.createdAt, f.segmentId, f.videoId, f.videoFrameIndex, \(projection.encodedAtColumn), \(projection.processingStatusColumn), \(projection.redactionReasonColumn),
                    \(projection.captureTriggerColumn),
                    s.bundleID, s.windowName, s.browserUrl, \(projection.mousePositionColumn), \(projection.scrollPositionColumn), \(projection.videoCurrentTimeColumn),
+                   \(projection.displayIDColumn), \(projection.displayStableIDColumn), \(projection.displayNameColumn),
                    \(Self.videoInfoProjection(source: config.source, frameAlias: "f", videoAlias: "v"))
             FROM frame f
             INNER JOIN segment s ON f.segmentId = s.id
@@ -2042,6 +2079,7 @@ public actor DataAdapter {
             SELECT f.id, f.createdAt, f.segmentId, f.videoId, f.videoFrameIndex, \(projection.encodedAtColumn), \(projection.processingStatusColumn), \(projection.redactionReasonColumn),
                    \(projection.captureTriggerColumn),
                    s.bundleID, s.windowName, s.browserUrl, \(projection.mousePositionColumn), \(projection.scrollPositionColumn), \(projection.videoCurrentTimeColumn),
+                   \(projection.displayIDColumn), \(projection.displayStableIDColumn), \(projection.displayNameColumn),
                    \(Self.videoInfoProjection(source: config.source, frameAlias: "f", videoAlias: "v"))
             FROM frame f
             INNER JOIN segment s ON f.segmentId = s.id
@@ -2125,6 +2163,7 @@ public actor DataAdapter {
             SELECT f.id, f.createdAt, f.segmentId, f.videoId, f.videoFrameIndex, \(projection.encodedAtColumn), \(projection.processingStatusColumn), \(projection.redactionReasonColumn),
                    \(projection.captureTriggerColumn),
                    s.bundleID, s.windowName, s.browserUrl, \(projection.mousePositionColumn), \(projection.scrollPositionColumn), \(projection.videoCurrentTimeColumn),
+                   \(projection.displayIDColumn), \(projection.displayStableIDColumn), \(projection.displayNameColumn),
                    \(Self.videoInfoProjection(source: config.source, frameAlias: "f", videoAlias: "v"))
             FROM frame f
             INNER JOIN segment s ON f.segmentId = s.id
@@ -2198,6 +2237,7 @@ public actor DataAdapter {
             SELECT f.id, f.createdAt, f.segmentId, f.videoId, f.videoFrameIndex, \(projection.encodedAtColumn), \(projection.processingStatusColumn), \(projection.redactionReasonColumn),
                    \(projection.captureTriggerColumn),
                    s.bundleID, s.windowName, s.browserUrl, \(projection.mousePositionColumn), \(projection.scrollPositionColumn), \(projection.videoCurrentTimeColumn),
+                   \(projection.displayIDColumn), \(projection.displayStableIDColumn), \(projection.displayNameColumn),
                    \(Self.videoInfoProjection(source: config.source, frameAlias: "f", videoAlias: "v"))
             FROM frame f
             INNER JOIN segment s ON f.segmentId = s.id
@@ -2277,6 +2317,7 @@ public actor DataAdapter {
             SELECT f.id, f.createdAt, f.segmentId, f.videoId, f.videoFrameIndex, \(projection.encodedAtColumn), \(projection.processingStatusColumn), \(projection.redactionReasonColumn),
                    \(projection.captureTriggerColumn),
                    s.bundleID, s.windowName, s.browserUrl, \(projection.mousePositionColumn), \(projection.scrollPositionColumn), \(projection.videoCurrentTimeColumn),
+                   \(projection.displayIDColumn), \(projection.displayStableIDColumn), \(projection.displayNameColumn),
                    \(Self.videoInfoProjection(source: config.source, frameAlias: "f", videoAlias: "v"))
             FROM frame f
             INNER JOIN segment s ON f.segmentId = s.id
@@ -2376,9 +2417,10 @@ public actor DataAdapter {
             SELECT f.id, f.createdAt, f.segmentId, f.videoId, f.videoFrameIndex, \(projection.encodedAtColumn), \(projection.processingStatusColumn), \(projection.redactionReasonColumn),
                    \(projection.captureTriggerColumn),
                    s.bundleID, s.windowName, s.browserUrl, \(projection.mousePositionColumn), \(projection.scrollPositionColumn), \(projection.videoCurrentTimeColumn),
+                   \(projection.displayIDColumn), \(projection.displayStableIDColumn), \(projection.displayNameColumn),
                    \(Self.videoInfoProjection(source: config.source, frameAlias: "f", videoAlias: "v"))
             FROM (
-                SELECT id, createdAt, segmentId, videoId, videoFrameIndex, \(subqueryProjection.encodedAtColumn), \(subqueryProjection.processingStatusColumn), \(subqueryProjection.redactionReasonColumn), \(subqueryProjection.captureTriggerColumn), \(subqueryProjection.mousePositionColumn), \(subqueryProjection.scrollPositionColumn), \(subqueryProjection.videoCurrentTimeColumn)
+                SELECT id, createdAt, segmentId, videoId, videoFrameIndex, \(subqueryProjection.encodedAtColumn), \(subqueryProjection.processingStatusColumn), \(subqueryProjection.redactionReasonColumn), \(subqueryProjection.captureTriggerColumn), \(subqueryProjection.mousePositionColumn), \(subqueryProjection.scrollPositionColumn), \(subqueryProjection.videoCurrentTimeColumn), \(subqueryProjection.displayIDColumn), \(subqueryProjection.displayStableIDColumn), \(subqueryProjection.displayNameColumn)
                 FROM frame
                 WHERE \(whereClause)
                 ORDER BY createdAt DESC
@@ -2480,9 +2522,10 @@ public actor DataAdapter {
             SELECT f.id, f.createdAt, f.segmentId, f.videoId, f.videoFrameIndex, \(projection.encodedAtColumn), \(projection.processingStatusColumn), \(projection.redactionReasonColumn),
                    \(projection.captureTriggerColumn),
                    s.bundleID, s.windowName, s.browserUrl, \(projection.mousePositionColumn), \(projection.scrollPositionColumn), \(projection.videoCurrentTimeColumn),
+                   \(projection.displayIDColumn), \(projection.displayStableIDColumn), \(projection.displayNameColumn),
                    \(Self.videoInfoProjection(source: config.source, frameAlias: "f", videoAlias: "v"))
             FROM (
-                SELECT id, createdAt, segmentId, videoId, videoFrameIndex, \(subqueryProjection.encodedAtColumn), \(subqueryProjection.processingStatusColumn), \(subqueryProjection.redactionReasonColumn), \(subqueryProjection.captureTriggerColumn), \(subqueryProjection.mousePositionColumn), \(subqueryProjection.scrollPositionColumn), \(subqueryProjection.videoCurrentTimeColumn)
+                SELECT id, createdAt, segmentId, videoId, videoFrameIndex, \(subqueryProjection.encodedAtColumn), \(subqueryProjection.processingStatusColumn), \(subqueryProjection.redactionReasonColumn), \(subqueryProjection.captureTriggerColumn), \(subqueryProjection.mousePositionColumn), \(subqueryProjection.scrollPositionColumn), \(subqueryProjection.videoCurrentTimeColumn), \(subqueryProjection.displayIDColumn), \(subqueryProjection.displayStableIDColumn), \(subqueryProjection.displayNameColumn)
                 FROM frame
                 WHERE \(whereClause)
                 ORDER BY createdAt ASC
@@ -2553,6 +2596,7 @@ public actor DataAdapter {
             SELECT f.id, f.createdAt, f.segmentId, f.videoId, f.videoFrameIndex, \(projection.encodedAtColumn), \(projection.processingStatusColumn), \(projection.redactionReasonColumn),
                    \(projection.captureTriggerColumn),
                    s.bundleID, s.windowName, s.browserUrl, \(projection.mousePositionColumn), \(projection.scrollPositionColumn), \(projection.videoCurrentTimeColumn),
+                   \(projection.displayIDColumn), \(projection.displayStableIDColumn), \(projection.displayNameColumn),
                    \(Self.videoInfoProjection(source: config.source, frameAlias: "f", videoAlias: "v"))
             FROM frame f
             LEFT JOIN segment s ON f.segmentId = s.id
@@ -4616,6 +4660,7 @@ public actor DataAdapter {
         let whereClauses: [String]
         let includedTagIDs: [Int64]
         let appBundleIDs: [String]
+        let displayStableIDs: [String]
         let metadataBindValues: [String]
         let dateRangeBounds: [Date]
         let sourceBoundaryBounds: [Date]
@@ -4637,6 +4682,7 @@ public actor DataAdapter {
             shouldApplyTagFilters: shouldApplyTagFilters
         )
         let appBundleIDs = filters.selectedApps?.sorted() ?? []
+        let displayStableIDs = filters.selectedDisplayStableIDs?.sorted() ?? []
         let windowNameFilter = Self.decodeMetadataStringFilter(filters.windowNameFilter)
         let browserUrlFilter = Self.decodeMetadataStringFilter(filters.browserUrlFilter)
 
@@ -4678,6 +4724,15 @@ public actor DataAdapter {
 
         if !appBundleIDs.isEmpty {
             whereClauses.append(Self.buildAppFilterClause(apps: Set(appBundleIDs), mode: filters.appFilterMode))
+        }
+
+        if !displayStableIDs.isEmpty {
+            if isRewindDatabase {
+                whereClauses.append("0")
+            } else {
+                let placeholders = displayStableIDs.map { _ in "?" }.joined(separator: ", ")
+                whereClauses.append("f.displayStableId IN (\(placeholders))")
+            }
         }
 
         Self.appendMetadataStringFilter(
@@ -4751,6 +4806,7 @@ public actor DataAdapter {
             whereClauses: whereClauses,
             includedTagIDs: includedTagIDs,
             appBundleIDs: appBundleIDs,
+            displayStableIDs: isRewindDatabase ? [] : displayStableIDs,
             metadataBindValues: metadataBindValues,
             dateRangeBounds: dateRangeFilter.bindValues,
             sourceBoundaryBounds: sourceBoundaryBounds,
@@ -4806,6 +4862,11 @@ public actor DataAdapter {
 
         for app in components.appBundleIDs {
             sqlite3_bind_text(statement, currentBindIndex, (app as NSString).utf8String, -1, nil)
+            currentBindIndex += 1
+        }
+
+        for displayStableID in components.displayStableIDs {
+            sqlite3_bind_text(statement, currentBindIndex, (displayStableID as NSString).utf8String, -1, nil)
             currentBindIndex += 1
         }
 
@@ -4904,15 +4965,19 @@ public actor DataAdapter {
         let mousePosition = Self.decodeStoredPoint(Self.getTextOrNil(statement, 12))
         let scrollY = Self.decodeStoredPoint(Self.getTextOrNil(statement, 13))?.y
         let videoCurrentTime = sqlite3_column_type(statement, 14) != SQLITE_NULL ? sqlite3_column_double(statement, 14) : nil
+        let displayID = sqlite3_column_type(statement, 15) != SQLITE_NULL ? UInt32(sqlite3_column_int(statement, 15)) : 0
+        let displayStableID = Self.getTextOrNil(statement, 16)
+        let displayName = Self.getTextOrNil(statement, 17)
 
-        let videoPath = Self.getTextOrNil(statement, 15)
-        let frameRate = sqlite3_column_type(statement, 16) != SQLITE_NULL ? sqlite3_column_double(statement, 16) : nil
-        let width = sqlite3_column_type(statement, 17) != SQLITE_NULL ? Int(sqlite3_column_int(statement, 17)) : nil
-        let height = sqlite3_column_type(statement, 18) != SQLITE_NULL ? Int(sqlite3_column_int(statement, 18)) : nil
-        let videoProcessingState = sqlite3_column_type(statement, 19) != SQLITE_NULL ? Int(sqlite3_column_int(statement, 19)) : 0
-        let fileSizeBytes = sqlite3_column_type(statement, 20) != SQLITE_NULL ? sqlite3_column_int64(statement, 20) : nil
-        let frameCount = sqlite3_column_type(statement, 21) != SQLITE_NULL ? Int(sqlite3_column_int(statement, 21)) : nil
-        let videoReencodedAt = config.parseDate(from: statement, column: 22)
+        let videoPath = Self.getTextOrNil(statement, 18)
+        let frameRate = sqlite3_column_type(statement, 19) != SQLITE_NULL ? sqlite3_column_double(statement, 19) : nil
+        let width = sqlite3_column_type(statement, 20) != SQLITE_NULL ? Int(sqlite3_column_int(statement, 20)) : nil
+        let height = sqlite3_column_type(statement, 21) != SQLITE_NULL ? Int(sqlite3_column_int(statement, 21)) : nil
+        let videoDisplayStableID = Self.getTextOrNil(statement, 22)
+        let videoProcessingState = sqlite3_column_type(statement, 23) != SQLITE_NULL ? Int(sqlite3_column_int(statement, 23)) : 0
+        let fileSizeBytes = sqlite3_column_type(statement, 24) != SQLITE_NULL ? sqlite3_column_int64(statement, 24) : nil
+        let frameCount = sqlite3_column_type(statement, 25) != SQLITE_NULL ? Int(sqlite3_column_int(statement, 25)) : nil
+        let videoReencodedAt = config.parseDate(from: statement, column: 26)
 
         let metadata = FrameMetadata(
             appBundleID: bundleID.isEmpty ? nil : bundleID,
@@ -4921,7 +4986,9 @@ public actor DataAdapter {
             browserURL: browserUrl,
             redactionReason: redactionReason,
             captureTrigger: captureTrigger,
-            displayID: 0,
+            displayID: displayID,
+            displayStableID: displayStableID,
+            displayName: displayName,
             mousePosition: mousePosition.map { CGPoint(x: $0.x, y: $0.y) }
         )
 
@@ -4945,6 +5012,7 @@ public actor DataAdapter {
                 frameRate: rate,
                 width: w,
                 height: h,
+                displayStableID: videoDisplayStableID,
                 isVideoFinalized: videoProcessingState == 0,
                 videoReencodedAt: videoReencodedAt,
                 fileSizeBytes: fileSizeBytes,

--- a/Capture/CaptureManager.swift
+++ b/Capture/CaptureManager.swift
@@ -176,8 +176,8 @@ public actor CaptureManager: CaptureProtocol {
     private let now: @Sendable () -> Date
 
     private var currentConfig: CaptureConfig
-    private var lastKeptFrame: CapturedFrame?
-    private var lastKeptMousePosition: CGPoint?
+    private var lastKeptFrameByDisplayKey: [String: CapturedFrame] = [:]
+    private var lastKeptMousePositionByDisplayKey: [String: CGPoint] = [:]
     private var _isCapturing = false
 
     private var dedupedFrameContinuation: AsyncStream<CapturedFrame>.Continuation?
@@ -316,8 +316,8 @@ public actor CaptureManager: CaptureProtocol {
         dedupedFrameContinuation = nil
         _frameStream = nil
 
-        lastKeptFrame = nil
-        lastKeptMousePosition = nil
+        lastKeptFrameByDisplayKey = [:]
+        lastKeptMousePositionByDisplayKey = [:]
         lastAcceptedWindowChangeSignature = nil
         updateCaptureMemoryLedger(currentFrameBytes: 0)
         currentCaptureDisplayID = nil
@@ -397,8 +397,8 @@ public actor CaptureManager: CaptureProtocol {
         latestWindowChangeEvent = nil
         deferredDisplaySyncTask?.cancel()
         deferredDisplaySyncTask = nil
-        lastKeptFrame = nil
-        lastKeptMousePosition = nil
+        lastKeptFrameByDisplayKey = [:]
+        lastKeptMousePositionByDisplayKey = [:]
         lastAcceptedWindowChangeSignature = nil
         updateCaptureMemoryLedger(currentFrameBytes: 0)
         totalCapturedBytes = 0
@@ -675,31 +675,42 @@ public actor CaptureManager: CaptureProtocol {
         }
 
         let captureAttemptStartedAt = now()
-        let displayID = await displayIDForCapture(trigger: capture.trigger)
-        currentCaptureDisplayID = displayID
+        let activeDisplayID = await displayIDForCapture(trigger: capture.trigger)
+        currentCaptureDisplayID = activeDisplayID
 
-        let frame = await cgWindowListCapture.captureFrame(displayID: displayID)
-        let captureAttemptCompletedAt = now()
-        if let frame {
-            lastActualCaptureTime = captureAttemptCompletedAt
-            if let windowChangeEvent = capture.windowChangeEvent {
-                let shouldDropFrame = shouldDropWindowChangeCapture(
-                    event: windowChangeEvent,
-                    capturedMetadata: frame.metadata
-                )
-                if shouldDropFrame {
-                    scheduleNextIntervalCapture(from: captureAttemptCompletedAt)
-                    if capture.trigger == .windowChange {
-                        await syncCaptureDisplayIfNeeded()
-                        scheduleDisplaySyncCheck()
-                    }
-                    return
-                }
+        let displayIDs = await displayIDsForCapture(trigger: capture.trigger, activeDisplayID: activeDisplayID)
+        var capturedFrames: [CapturedFrame] = []
+        capturedFrames.reserveCapacity(displayIDs.count)
+        for displayID in displayIDs {
+            if let frame = await cgWindowListCapture.captureFrame(displayID: displayID) {
+                capturedFrames.append(frame)
             }
-            if let windowChangeSignature = capture.windowChangeSignature {
+        }
+
+        let captureAttemptCompletedAt = now()
+        if !capturedFrames.isEmpty {
+            lastActualCaptureTime = captureAttemptCompletedAt
+            var keptAnyFrame = false
+
+            for frame in capturedFrames {
+                if let windowChangeEvent = capture.windowChangeEvent,
+                   frame.metadata.displayID == activeDisplayID {
+                    let shouldDropFrame = shouldDropWindowChangeCapture(
+                        event: windowChangeEvent,
+                        capturedMetadata: frame.metadata
+                    )
+                    if shouldDropFrame {
+                        continue
+                    }
+                }
+
+                await handleCapturedFrame(frame, trigger: capture.trigger)
+                keptAnyFrame = true
+            }
+
+            if keptAnyFrame, let windowChangeSignature = capture.windowChangeSignature {
                 lastAcceptedWindowChangeSignature = windowChangeSignature
             }
-            await handleCapturedFrame(frame, trigger: capture.trigger)
             scheduleNextIntervalCapture(from: captureAttemptCompletedAt)
         } else {
             scheduleNextIntervalCapture(from: max(captureAttemptStartedAt, captureAttemptCompletedAt))
@@ -709,6 +720,31 @@ public actor CaptureManager: CaptureProtocol {
             await syncCaptureDisplayIfNeeded()
             scheduleDisplaySyncCheck()
         }
+    }
+
+    private func displayIDsForCapture(trigger: CaptureTrigger, activeDisplayID: UInt32) async -> [UInt32] {
+        do {
+            let displays = try await displayMonitor.getAvailableDisplays()
+            let displayIDs = displays
+                .sorted { lhs, rhs in
+                    if lhs.id == activeDisplayID { return true }
+                    if rhs.id == activeDisplayID { return false }
+                    if lhs.isMain != rhs.isMain { return lhs.isMain }
+                    return lhs.id < rhs.id
+                }
+                .map(\.id)
+            if !displayIDs.isEmpty {
+                var seen = Set<UInt32>()
+                return displayIDs.filter { seen.insert($0).inserted }
+            }
+        } catch {
+            Log.warning(
+                "[CaptureManager] Failed to enumerate displays for \(Self.triggerLogDescription(for: trigger)); falling back to active display: \(error.localizedDescription)",
+                category: .capture
+            )
+        }
+
+        return [activeDisplayID]
     }
 
     private func displayIDForCapture(trigger: CaptureTrigger) async -> UInt32 {
@@ -852,24 +888,31 @@ public actor CaptureManager: CaptureProtocol {
         let currentMousePosition = currentConfig.keepFramesOnMouseMovement
             ? Self.mousePositionWithinCapturedFrame(frame)
             : nil
+        let displayKey = Self.displayDeduplicationKey(for: frame)
+        let previousFrame = lastKeptFrameByDisplayKey[displayKey]
+        let previousMousePosition = lastKeptMousePositionByDisplayKey[displayKey]
 
         if currentConfig.adaptiveCaptureEnabled {
-            let similarity = lastKeptFrame.map { deduplicator.computeSimilarity(frame, $0) }
+            let similarity = previousFrame.map { deduplicator.computeSimilarity(frame, $0) }
             let keepBySimilarity = deduplicator.shouldKeepFrame(
                 frame,
-                comparedTo: lastKeptFrame,
+                comparedTo: previousFrame,
                 threshold: currentConfig.deduplicationThreshold
             )
             let keepByMouseMovement = Self.shouldKeepFrameForMouseMovement(
                 enabled: currentConfig.keepFramesOnMouseMovement,
-                previousMousePosition: lastKeptMousePosition,
+                previousMousePosition: previousMousePosition,
                 currentMousePosition: currentMousePosition
             )
             let shouldKeep = keepBySimilarity || keepByMouseMovement
 
             if shouldKeep {
-                lastKeptFrame = frame
-                lastKeptMousePosition = currentMousePosition
+                lastKeptFrameByDisplayKey[displayKey] = frame
+                if let currentMousePosition {
+                    lastKeptMousePositionByDisplayKey[displayKey] = currentMousePosition
+                } else {
+                    lastKeptMousePositionByDisplayKey.removeValue(forKey: displayKey)
+                }
                 let enrichedFrame = await enrichFrameMetadata(frame, trigger: trigger)
                 dedupedFrameContinuation?.yield(enrichedFrame)
 
@@ -932,8 +975,12 @@ public actor CaptureManager: CaptureProtocol {
                 captureStartTime: stats.captureStartTime,
                 lastFrameTime: enrichedFrame.timestamp
             )
-            lastKeptFrame = frame
-            lastKeptMousePosition = currentMousePosition
+            lastKeptFrameByDisplayKey[displayKey] = frame
+            if let currentMousePosition {
+                lastKeptMousePositionByDisplayKey[displayKey] = currentMousePosition
+            } else {
+                lastKeptMousePositionByDisplayKey.removeValue(forKey: displayKey)
+            }
 
             if trigger == .mouseClick {
                 reportMouseClickOutcome(.captured)
@@ -971,7 +1018,9 @@ public actor CaptureManager: CaptureProtocol {
 
     private func updateCaptureMemoryLedger(currentFrameBytes: Int64) {
         let normalizedCurrentFrameBytes = max(0, currentFrameBytes)
-        let lastKeptFrameBytes = Int64(lastKeptFrame?.imageData.count ?? 0)
+        let lastKeptFrameBytes = lastKeptFrameByDisplayKey.values.reduce(Int64(0)) { partialResult, frame in
+            partialResult + Int64(frame.imageData.count)
+        }
 
         MemoryLedger.set(
             tag: Self.memoryLedgerCurrentFrameTag,
@@ -984,7 +1033,7 @@ public actor CaptureManager: CaptureProtocol {
         MemoryLedger.set(
             tag: Self.memoryLedgerLastKeptFrameTag,
             bytes: lastKeptFrameBytes,
-            count: lastKeptFrame == nil ? 0 : 1,
+            count: lastKeptFrameByDisplayKey.count,
             unit: "frames",
             function: "capture.deduplication",
             kind: "reference-frame",
@@ -995,6 +1044,15 @@ public actor CaptureManager: CaptureProtocol {
             category: .capture,
             minIntervalSeconds: Self.memoryLedgerSummaryIntervalSeconds
         )
+    }
+
+    private static func displayDeduplicationKey(for frame: CapturedFrame) -> String {
+        if let displayStableID = frame.metadata.displayStableID,
+           !displayStableID.isEmpty {
+            return displayStableID
+        }
+
+        return "runtime-display:\(frame.metadata.displayID)"
     }
 
     static func shouldKeepFrameForMouseMovement(
@@ -1088,6 +1146,8 @@ public actor CaptureManager: CaptureProtocol {
         )
         let redactionReason = frame.metadata.redactionReason
         let preservedDisplayID = frame.metadata.displayID != 0 ? frame.metadata.displayID : frontmostMetadata.displayID
+        let preservedDisplayStableID = frame.metadata.displayStableID ?? frontmostMetadata.displayStableID
+        let preservedDisplayName = frame.metadata.displayName ?? frontmostMetadata.displayName
         let captureTrigger = frame.metadata.captureTrigger ?? Self.storedCaptureTrigger(for: trigger)
 
         let enrichedMetadata: FrameMetadata
@@ -1099,7 +1159,9 @@ public actor CaptureManager: CaptureProtocol {
                 browserURL: frame.metadata.browserURL ?? frontmostMetadata.browserURL,
                 redactionReason: redactionReason,
                 captureTrigger: captureTrigger,
-                displayID: preservedDisplayID
+                displayID: preservedDisplayID,
+                displayStableID: preservedDisplayStableID,
+                displayName: preservedDisplayName
             )
         } else {
             enrichedMetadata = FrameMetadata(
@@ -1109,7 +1171,9 @@ public actor CaptureManager: CaptureProtocol {
                 browserURL: nil,
                 redactionReason: redactionReason,
                 captureTrigger: captureTrigger,
-                displayID: preservedDisplayID
+                displayID: preservedDisplayID,
+                displayStableID: preservedDisplayStableID,
+                displayName: preservedDisplayName
             )
         }
 

--- a/Capture/Metadata/AppInfoProvider.swift
+++ b/Capture/Metadata/AppInfoProvider.swift
@@ -25,6 +25,11 @@ struct AppInfoProvider: Sendable {
         preferredDisplayID: CGDirectDisplayID? = nil
     ) async -> FrameMetadata {
         let displayID = preferredDisplayID ?? CGMainDisplayID()
+        let displayIdentity = DisplayIdentity.fromRuntimeDisplayID(
+            displayID,
+            name: displayName(for: displayID),
+            isMain: displayID == CGMainDisplayID()
+        )
         // Prefer top-most visible window metadata from CGWindowList to keep app/window
         // context aligned with the captured pixels, especially during rapid app switches.
         if let visibleWindow = getTopVisibleWindowContext(preferredDisplayID: preferredDisplayID) {
@@ -55,7 +60,9 @@ struct AppInfoProvider: Sendable {
                 appName: appName,
                 windowName: windowName,
                 browserURL: browserURL,
-                displayID: displayID
+                displayID: displayID,
+                displayStableID: displayIdentity.stableID,
+                displayName: displayIdentity.name
             )
             return metadata
         }
@@ -64,7 +71,11 @@ struct AppInfoProvider: Sendable {
         guard let frontApp = await MainActor.run(body: {
             NSWorkspace.shared.frontmostApplication
         }) else {
-            return FrameMetadata(displayID: displayID)
+            return FrameMetadata(
+                displayID: displayID,
+                displayStableID: displayIdentity.stableID,
+                displayName: displayIdentity.name
+            )
         }
 
         var bundleID = frontApp.bundleIdentifier
@@ -94,12 +105,23 @@ struct AppInfoProvider: Sendable {
             appName: appName,
             windowName: windowName,
             browserURL: browserURL,
-            displayID: displayID
+            displayID: displayID,
+            displayStableID: displayIdentity.stableID,
+            displayName: displayIdentity.name
         )
         return metadata
     }
 
     // MARK: - Private Helpers
+
+    private func displayName(for displayID: UInt32) -> String? {
+        if displayID == CGMainDisplayID() {
+            return "Main Display"
+        }
+
+        guard displayID != 0 else { return nil }
+        return "Display \(displayID)"
+    }
 
     /// Get the title of the focused window.
     /// Uses AX first, then falls back to CGWindow metadata for apps/PWAs that

--- a/Capture/ScreenCapture/CGWindowListCapture.swift
+++ b/Capture/ScreenCapture/CGWindowListCapture.swift
@@ -397,6 +397,14 @@ public actor CGWindowListCapture {
         let resolvedAppBundleID = redactionSummary?.appBundleID ?? visibleWindowContext?.appBundleID
         let resolvedAppName = redactionSummary?.appName ?? visibleWindowContext?.appName
         let resolvedWindowName = redactionSummary == nil ? visibleWindowContext?.windowName : nil
+        let displayName = displayName(for: UInt32(displayID))
+        let displayIdentity = DisplayIdentity.fromRuntimeDisplayID(
+            UInt32(displayID),
+            name: displayName,
+            width: width,
+            height: height,
+            isMain: UInt32(displayID) == CGMainDisplayID()
+        )
 
         // Create captured frame
         let frame = CapturedFrame(
@@ -410,11 +418,22 @@ public actor CGWindowListCapture {
                 appName: resolvedAppName,
                 windowName: resolvedWindowName,
                 redactionReason: redactionSummary?.reason,
-                displayID: UInt32(displayID)
+                displayID: UInt32(displayID),
+                displayStableID: displayIdentity.stableID,
+                displayName: displayIdentity.name
             )
         )
 
         return frame
+    }
+
+    private func displayName(for displayID: UInt32) -> String? {
+        if displayID == CGMainDisplayID() {
+            return "Main Display"
+        }
+
+        guard displayID != 0 else { return nil }
+        return "Display \(displayID)"
     }
 
     /// Compute which window IDs should be excluded based on current config

--- a/Capture/ScreenCapture/DisplayMonitor.swift
+++ b/Capture/ScreenCapture/DisplayMonitor.swift
@@ -33,13 +33,28 @@ actor DisplayMonitor {
 
         let mainDisplayID = CGMainDisplayID()
         let displays = content.displays.map { display in
-            DisplayInfo(
+            let displayName = getDisplayName(for: display.displayID)
+            let vendorNumber = CGDisplayVendorNumber(display.displayID)
+            let modelNumber = CGDisplayModelNumber(display.displayID)
+            let serialNumber = CGDisplaySerialNumber(display.displayID)
+            return DisplayInfo(
                 id: display.displayID,
                 width: display.width,
                 height: display.height,
                 scaleFactor: getScaleFactor(for: display.displayID),
                 isMain: display.displayID == mainDisplayID,
-                name: getDisplayName(for: display.displayID)
+                name: displayName,
+                stableID: DisplayIdentity.stableID(
+                    vendorNumber: vendorNumber,
+                    modelNumber: modelNumber,
+                    serialNumber: serialNumber,
+                    width: display.width,
+                    height: display.height,
+                    name: displayName
+                ),
+                vendorNumber: vendorNumber,
+                modelNumber: modelNumber,
+                serialNumber: serialNumber
             )
         }
 

--- a/Database/DatabaseManager.swift
+++ b/Database/DatabaseManager.swift
@@ -945,10 +945,27 @@ public actor DatabaseManager: DatabaseProtocol {
     // MARK: - Unfinalised Video Operations (Multi-Resolution Support)
 
     public func getUnfinalisedVideoByResolution(width: Int, height: Int) async throws -> UnfinalisedVideo? {
+        try await getUnfinalisedVideoByResolution(
+            width: width,
+            height: height,
+            displayStableID: nil
+        )
+    }
+
+    public func getUnfinalisedVideoByResolution(
+        width: Int,
+        height: Int,
+        displayStableID: String?
+    ) async throws -> UnfinalisedVideo? {
         guard let db = db else {
             throw DatabaseError.connectionFailed(underlying: "Database not initialized")
         }
-        return try SegmentQueries.getUnfinalisedByResolution(db: db, width: width, height: height)
+        return try SegmentQueries.getUnfinalisedByResolution(
+            db: db,
+            width: width,
+            height: height,
+            displayStableID: displayStableID
+        )
     }
 
     public func getAllUnfinalisedVideos() async throws -> [UnfinalisedVideo] {

--- a/Database/Migrations/MigrationRunner.swift
+++ b/Database/Migrations/MigrationRunner.swift
@@ -106,7 +106,8 @@ actor MigrationRunner {
             V16_ProcessingQueueFrameIDIndex(),
             V17_FrameCaptureTrigger(),
             V18_DailyMetricsRecencyIndex(),
-            V19_FrameEncodedAt()
+            V19_FrameEncodedAt(),
+            V20_DisplayIdentity()
         ]
     }
 

--- a/Database/Migrations/V20_DisplayIdentity.swift
+++ b/Database/Migrations/V20_DisplayIdentity.swift
@@ -1,0 +1,90 @@
+import Foundation
+import SQLCipher
+import Shared
+
+/// V20 Migration: persist display identity for multi-monitor capture.
+/// `displayId` is the runtime CoreGraphics ID; `displayStableId` is the
+/// hardware-derived key used to correlate the same monitor across hotplug.
+struct V20_DisplayIdentity: Migration {
+    let version = 20
+
+    func migrate(db: OpaquePointer) async throws {
+        Log.info("🖥️ Ensuring display identity columns...", category: .database)
+
+        if !(try hasColumn(db: db, table: "frame", column: "displayId")) {
+            try execute(db: db, sql: "ALTER TABLE frame ADD COLUMN displayId INTEGER;")
+            Log.debug("✓ Added frame.displayId column")
+        }
+
+        if !(try hasColumn(db: db, table: "frame", column: "displayStableId")) {
+            try execute(db: db, sql: "ALTER TABLE frame ADD COLUMN displayStableId TEXT;")
+            Log.debug("✓ Added frame.displayStableId column")
+        }
+
+        if !(try hasColumn(db: db, table: "frame", column: "displayName")) {
+            try execute(db: db, sql: "ALTER TABLE frame ADD COLUMN displayName TEXT;")
+            Log.debug("✓ Added frame.displayName column")
+        }
+
+        if !(try hasColumn(db: db, table: "video", column: "displayStableId")) {
+            try execute(db: db, sql: "ALTER TABLE video ADD COLUMN displayStableId TEXT;")
+            Log.debug("✓ Added video.displayStableId column")
+        }
+
+        try execute(
+            db: db,
+            sql: """
+                CREATE INDEX IF NOT EXISTS idx_frame_display_stable_created_at
+                ON frame(displayStableId, createdAt)
+                WHERE displayStableId IS NOT NULL;
+                """
+        )
+
+        try execute(db: db, sql: "DROP INDEX IF EXISTS index_video_on_unfinalized_resolution;")
+        try execute(
+            db: db,
+            sql: """
+                CREATE INDEX IF NOT EXISTS index_video_on_unfinalized_display_resolution
+                ON video(displayStableId, width, height, processingState)
+                WHERE processingState = 1;
+                """
+        )
+
+        Log.info("✅ V20 migration completed: display identity persisted", category: .database)
+    }
+
+    private func hasColumn(db: OpaquePointer, table: String, column: String) throws -> Bool {
+        let sql = "PRAGMA table_info(\(table));"
+        var statement: OpaquePointer?
+        defer { sqlite3_finalize(statement) }
+
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            throw DatabaseError.migrationFailed(
+                version: version,
+                underlying: "Failed to inspect table info: \(String(cString: sqlite3_errmsg(db)))"
+            )
+        }
+
+        while sqlite3_step(statement) == SQLITE_ROW {
+            guard let name = sqlite3_column_text(statement, 1).map({ String(cString: $0) }) else {
+                continue
+            }
+            if name == column {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    private func execute(db: OpaquePointer, sql: String) throws {
+        var errorPointer: UnsafeMutablePointer<CChar>?
+        let result = sqlite3_exec(db, sql, nil, nil, &errorPointer)
+
+        if result != SQLITE_OK {
+            let errorMessage = errorPointer.flatMap { String(cString: $0) } ?? "Unknown error"
+            sqlite3_free(errorPointer)
+            throw DatabaseError.migrationFailed(version: version, underlying: "SQL execution failed: \(errorMessage)")
+        }
+    }
+}

--- a/Database/Queries/FrameQueries.swift
+++ b/Database/Queries/FrameQueries.swift
@@ -14,8 +14,8 @@ public enum FrameQueries {
     static func insert(db: OpaquePointer, frame: FrameReference) throws -> Int64 {
         let sql = """
             INSERT INTO frame (
-                createdAt, imageFileName, segmentId, videoId, videoFrameIndex, isStarred, redactionReason, capture_trigger, processingStatus
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 4);
+                createdAt, imageFileName, segmentId, videoId, videoFrameIndex, isStarred, redactionReason, capture_trigger, displayId, displayStableId, displayName, processingStatus
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 4);
             """
 
         var statement: OpaquePointer?
@@ -59,6 +59,9 @@ public enum FrameQueries {
         // redactionReason: nullable, set when frame pixels were intentionally redacted
         bindTextOrNull(statement, 7, frame.metadata.redactionReason)
         bindTextOrNull(statement, 8, frame.metadata.captureTrigger?.rawValue)
+        sqlite3_bind_int(statement, 9, Int32(frame.metadata.displayID))
+        bindTextOrNull(statement, 10, frame.metadata.displayStableID)
+        bindTextOrNull(statement, 11, frame.metadata.displayName)
 
         guard sqlite3_step(statement) == SQLITE_DONE else {
             throw DatabaseError.queryFailed(
@@ -878,7 +881,8 @@ public enum FrameQueries {
     static func getByID(db: OpaquePointer, id: FrameID) throws -> FrameReference? {
         let sql = """
             SELECT f.id, f.createdAt, f.segmentId, f.videoId, f.videoFrameIndex, f.isStarred, f.encodedAt,
-                   f.redactionReason, f.capture_trigger, s.bundleID, s.windowName, s.browserUrl, f.mousePosition
+                   f.redactionReason, f.capture_trigger, s.bundleID, s.windowName, s.browserUrl, f.mousePosition,
+                   f.displayId, f.displayStableId, f.displayName
             FROM frame f
             LEFT JOIN segment s ON f.segmentId = s.id
             WHERE f.id = ?;
@@ -915,7 +919,8 @@ public enum FrameQueries {
     ) throws -> [FrameReference] {
         let sql = """
             SELECT f.id, f.createdAt, f.segmentId, f.videoId, f.videoFrameIndex, f.isStarred, f.encodedAt,
-                   f.redactionReason, f.capture_trigger, s.bundleID, s.windowName, s.browserUrl, f.mousePosition
+                   f.redactionReason, f.capture_trigger, s.bundleID, s.windowName, s.browserUrl, f.mousePosition,
+                   f.displayId, f.displayStableId, f.displayName
             FROM frame f
             LEFT JOIN segment s ON f.segmentId = s.id
             WHERE f.createdAt >= ? AND f.createdAt <= ?
@@ -957,7 +962,8 @@ public enum FrameQueries {
     ) throws -> [FrameReference] {
         let sql = """
             SELECT f.id, f.createdAt, f.segmentId, f.videoId, f.videoFrameIndex, f.isStarred, f.encodedAt,
-                   f.redactionReason, f.capture_trigger, s.bundleID, s.windowName, s.browserUrl, f.mousePosition
+                   f.redactionReason, f.capture_trigger, s.bundleID, s.windowName, s.browserUrl, f.mousePosition,
+                   f.displayId, f.displayStableId, f.displayName
             FROM frame f
             LEFT JOIN segment s ON f.segmentId = s.id
             WHERE f.createdAt < ?
@@ -998,7 +1004,8 @@ public enum FrameQueries {
     ) throws -> [FrameReference] {
         let sql = """
             SELECT f.id, f.createdAt, f.segmentId, f.videoId, f.videoFrameIndex, f.isStarred, f.encodedAt,
-                   f.redactionReason, f.capture_trigger, s.bundleID, s.windowName, s.browserUrl, f.mousePosition
+                   f.redactionReason, f.capture_trigger, s.bundleID, s.windowName, s.browserUrl, f.mousePosition,
+                   f.displayId, f.displayStableId, f.displayName
             FROM frame f
             LEFT JOIN segment s ON f.segmentId = s.id
             WHERE f.createdAt >= ?
@@ -1035,7 +1042,8 @@ public enum FrameQueries {
     static func getMostRecent(db: OpaquePointer, limit: Int) throws -> [FrameReference] {
         let sql = """
             SELECT f.id, f.createdAt, f.segmentId, f.videoId, f.videoFrameIndex, f.isStarred, f.encodedAt,
-                   f.redactionReason, f.capture_trigger, s.bundleID, s.windowName, s.browserUrl, f.mousePosition
+                   f.redactionReason, f.capture_trigger, s.bundleID, s.windowName, s.browserUrl, f.mousePosition,
+                   f.displayId, f.displayStableId, f.displayName
             FROM frame f
             LEFT JOIN segment s ON f.segmentId = s.id
             ORDER BY f.createdAt DESC
@@ -1075,7 +1083,8 @@ public enum FrameQueries {
     ) throws -> [FrameReference] {
         let sql = """
             SELECT f.id, f.createdAt, f.segmentId, f.videoId, f.videoFrameIndex, f.isStarred, f.encodedAt,
-                   f.redactionReason, f.capture_trigger, s.bundleID, s.windowName, s.browserUrl, f.mousePosition
+                   f.redactionReason, f.capture_trigger, s.bundleID, s.windowName, s.browserUrl, f.mousePosition,
+                   f.displayId, f.displayStableId, f.displayName
             FROM frame f
             INNER JOIN segment s ON f.segmentId = s.id
             WHERE s.bundleID = ?
@@ -1114,7 +1123,8 @@ public enum FrameQueries {
     static func getFramesPendingVideoEncoding(db: OpaquePointer, limit: Int) throws -> [FrameReference] {
         let sql = """
             SELECT f.id, f.createdAt, f.segmentId, f.videoId, f.videoFrameIndex, f.isStarred, f.encodedAt,
-                   f.redactionReason, f.capture_trigger, s.bundleID, s.windowName, s.browserUrl, f.mousePosition
+                   f.redactionReason, f.capture_trigger, s.bundleID, s.windowName, s.browserUrl, f.mousePosition,
+                   f.displayId, f.displayStableId, f.displayName
             FROM frame f
             LEFT JOIN segment s ON f.segmentId = s.id
             WHERE f.videoId IS NULL
@@ -1381,13 +1391,16 @@ public enum FrameQueries {
         // Column 6: encodedAt (INTEGER - ms since epoch, nullable)
         let encodedAt = dateOrNil(statement, 6)
 
-        // Columns 7-12: Trigger + window metadata from frame/segment JOIN (nullable)
+        // Columns 7-15: Trigger, window, and display metadata from frame/segment JOIN (nullable)
         let redactionReason = getTextOrNil(statement, 7)
         let captureTrigger = getTextOrNil(statement, 8).flatMap(FrameCaptureTrigger.init(rawValue:))
         let appBundleID = getTextOrNil(statement, 9)
         let windowName = getTextOrNil(statement, 10)
         let browserURL = getTextOrNil(statement, 11)
         let mousePosition = decodePoint(getTextOrNil(statement, 12))
+        let displayID = sqlite3_column_type(statement, 13) != SQLITE_NULL ? UInt32(sqlite3_column_int(statement, 13)) : 0
+        let displayStableID = getTextOrNil(statement, 14)
+        let displayName = getTextOrNil(statement, 15)
 
         let metadata = FrameMetadata(
             appBundleID: appBundleID,
@@ -1396,6 +1409,9 @@ public enum FrameQueries {
             browserURL: browserURL,
             redactionReason: redactionReason,
             captureTrigger: captureTrigger,
+            displayID: displayID,
+            displayStableID: displayStableID,
+            displayName: displayName,
             mousePosition: mousePosition.map { CGPoint(x: $0.x, y: $0.y) }
         )
 

--- a/Database/Queries/SegmentQueries.swift
+++ b/Database/Queries/SegmentQueries.swift
@@ -14,8 +14,8 @@ enum SegmentQueries {
         // We use relativePath for the same purpose
         let sql = """
             INSERT INTO video (
-                height, width, path, fileSize, frameRate, processingState
-            ) VALUES (?, ?, ?, ?, ?, ?);
+                height, width, path, fileSize, frameRate, processingState, displayStableId
+            ) VALUES (?, ?, ?, ?, ?, ?, ?);
             """
 
         var statement: OpaquePointer?
@@ -39,6 +39,7 @@ enum SegmentQueries {
         sqlite3_bind_double(statement, 5, 30.0)
         // processingState: 1 = in progress (still being written to), 0 = completed
         sqlite3_bind_int(statement, 6, 1)
+        bindTextOrNull(statement, 7, segment.displayStableID)
 
         guard sqlite3_step(statement) == SQLITE_DONE else {
             throw DatabaseError.queryFailed(
@@ -185,11 +186,19 @@ enum SegmentQueries {
     /// Get an unfinalised video matching the given resolution
     /// Returns nil if no unfinalised video exists for this resolution
     /// Used to resume writing to an existing video when a frame with matching resolution comes in
-    static func getUnfinalisedByResolution(db: OpaquePointer, width: Int, height: Int) throws -> UnfinalisedVideo? {
+    static func getUnfinalisedByResolution(
+        db: OpaquePointer,
+        width: Int,
+        height: Int,
+        displayStableID: String? = nil
+    ) throws -> UnfinalisedVideo? {
         let sql = """
-            SELECT id, path, frameCount
+            SELECT id, path, frameCount, displayStableId
             FROM video
-            WHERE width = ? AND height = ? AND processingState = 1
+            WHERE width = ?
+              AND height = ?
+              AND processingState = 1
+              AND ((? IS NULL AND displayStableId IS NULL) OR displayStableId = ?)
             LIMIT 1;
             """
 
@@ -207,6 +216,8 @@ enum SegmentQueries {
 
         sqlite3_bind_int(statement, 1, Int32(width))
         sqlite3_bind_int(statement, 2, Int32(height))
+        bindTextOrNull(statement, 3, displayStableID)
+        bindTextOrNull(statement, 4, displayStableID)
 
         guard sqlite3_step(statement) == SQLITE_ROW else {
             return nil
@@ -218,13 +229,15 @@ enum SegmentQueries {
         }
         let path = String(cString: pathText)
         let frameCount = Int(sqlite3_column_int(statement, 2))
+        let displayStableID = getTextOrNil(statement!, 3)
 
         return UnfinalisedVideo(
             id: id,
             relativePath: path,
             frameCount: frameCount,
             width: width,
-            height: height
+            height: height,
+            displayStableID: displayStableID
         )
     }
 
@@ -232,7 +245,7 @@ enum SegmentQueries {
     /// processingState = 1 means video is still being written to
     static func getAllUnfinalised(db: OpaquePointer) throws -> [UnfinalisedVideo] {
         let sql = """
-            SELECT id, path, frameCount, width, height
+            SELECT id, path, frameCount, width, height, displayStableId
             FROM video
             WHERE processingState = 1;
             """
@@ -257,13 +270,15 @@ enum SegmentQueries {
             let frameCount = Int(sqlite3_column_int(statement, 2))
             let width = Int(sqlite3_column_int(statement, 3))
             let height = Int(sqlite3_column_int(statement, 4))
+            let displayStableID = getTextOrNil(statement!, 5)
 
             results.append(UnfinalisedVideo(
                 id: id,
                 relativePath: path,
                 frameCount: frameCount,
                 width: width,
-                height: height
+                height: height,
+                displayStableID: displayStableID
             ))
         }
 
@@ -274,7 +289,7 @@ enum SegmentQueries {
 
     static func getByID(db: OpaquePointer, id: VideoSegmentID) throws -> VideoSegment? {
         let sql = """
-            SELECT id, height, width, path, fileSize, frameCount, frameRate
+            SELECT id, height, width, path, fileSize, frameCount, frameRate, displayStableId
             FROM video
             WHERE id = ?;
             """
@@ -302,7 +317,7 @@ enum SegmentQueries {
 
     static func findByRelativePathStem(db: OpaquePointer, stem: String) throws -> VideoSegment? {
         let sql = """
-            SELECT id, height, width, path, fileSize, frameCount, frameRate
+            SELECT id, height, width, path, fileSize, frameCount, frameRate, displayStableId
             FROM video
             WHERE path = ?
                OR path = ?
@@ -342,7 +357,7 @@ enum SegmentQueries {
     static func getByTimestamp(db: OpaquePointer, timestamp: Date) throws -> VideoSegment? {
         // Query through frames to find the video
         let sql = """
-            SELECT DISTINCT v.id, v.height, v.width, v.path, v.fileSize, v.frameCount, v.frameRate
+            SELECT DISTINCT v.id, v.height, v.width, v.path, v.fileSize, v.frameCount, v.frameRate, v.displayStableId
             FROM video v
             INNER JOIN frame f ON f.videoId = v.id
             WHERE f.createdAt = ?
@@ -380,7 +395,7 @@ enum SegmentQueries {
         to endDate: Date
     ) throws -> [VideoSegment] {
         let sql = """
-            SELECT DISTINCT v.id, v.height, v.width, v.path, v.fileSize, v.frameCount, v.frameRate
+            SELECT DISTINCT v.id, v.height, v.width, v.path, v.fileSize, v.frameCount, v.frameRate, v.displayStableId
             FROM video v
             INNER JOIN frame f ON f.videoId = v.id
             WHERE f.createdAt >= ? AND f.createdAt <= ?
@@ -487,7 +502,7 @@ enum SegmentQueries {
     // MARK: - Helpers
 
     /// Parse a video row from the video table
-    /// Expected columns: id, height, width, path, fileSize, frameCount, frameRate
+    /// Expected columns: id, height, width, path, fileSize, frameCount, frameRate, displayStableId
     private static func parseVideoRow(statement: OpaquePointer) throws -> VideoSegment {
         // Column 0: id (INTEGER)
         let videoId = sqlite3_column_int64(statement, 0)
@@ -514,6 +529,9 @@ enum SegmentQueries {
         // Column 6: frameRate (currently unused by VideoSegment)
         _ = sqlite3_column_double(statement, 6)
 
+        // Column 7: displayStableId (nullable)
+        let displayStableID = getTextOrNil(statement, 7)
+
         // Note: The video table doesn't have startTime/endTime.
         // Those need to be queried from the frames table if needed.
         let startTime = Date(timeIntervalSince1970: 0)
@@ -528,7 +546,24 @@ enum SegmentQueries {
             relativePath: relativePath,
             width: width,
             height: height,
+            displayStableID: displayStableID,
             source: .native  // Retrace creates native videos
         )
+    }
+
+    private static func bindTextOrNull(_ statement: OpaquePointer?, _ index: Int32, _ value: String?) {
+        if let value {
+            sqlite3_bind_text(statement, index, value, -1, SQLITE_TRANSIENT)
+        } else {
+            sqlite3_bind_null(statement, index)
+        }
+    }
+
+    private static func getTextOrNil(_ statement: OpaquePointer, _ index: Int32) -> String? {
+        guard sqlite3_column_type(statement, index) != SQLITE_NULL,
+              let text = sqlite3_column_text(statement, index) else {
+            return nil
+        }
+        return String(cString: text)
     }
 }

--- a/Database/Tests/QueryBuilderTests.swift
+++ b/Database/Tests/QueryBuilderTests.swift
@@ -45,7 +45,8 @@ final class QueryBuilderTests: XCTestCase {
         endTime: Date? = nil,
         frameCount: Int = 100,
         fileSizeBytes: Int64 = 1024,
-        relativePath: String = "test.mp4"
+        relativePath: String = "test.mp4",
+        displayStableID: String? = nil
     ) -> VideoSegment {
         VideoSegment(
             id: id,
@@ -55,7 +56,8 @@ final class QueryBuilderTests: XCTestCase {
             fileSizeBytes: fileSizeBytes,
             relativePath: relativePath,
             width: 1920,
-            height: 1080
+            height: 1080,
+            displayStableID: displayStableID
         )
     }
 
@@ -187,6 +189,16 @@ final class QueryBuilderTests: XCTestCase {
         XCTAssertEqual(retrieved?.fileSizeBytes, 1024000)
         XCTAssertEqual(retrieved?.width, 1920)
         XCTAssertEqual(retrieved?.height, 1080)
+    }
+
+    func testSegmentQueries_DisplayStableID_RoundTrips() throws {
+        let stableDisplayID = "display:v123:m456:s789"
+        let segment = makeSegment(displayStableID: stableDisplayID)
+        let insertedID = try SegmentQueries.insert(db: db!, segment: segment)
+
+        let retrieved = try SegmentQueries.getByID(db: db!, id: VideoSegmentID(value: insertedID))
+
+        XCTAssertEqual(retrieved?.displayStableID, stableDisplayID)
     }
 
     func testSegmentQueries_GetByID_ReturnsNilForMissingID() throws {
@@ -428,6 +440,26 @@ final class QueryBuilderTests: XCTestCase {
         XCTAssertNil(retrieved?.metadata.appName)
         XCTAssertEqual(retrieved?.metadata.windowName, "GitHub - retrace")
         XCTAssertEqual(retrieved?.metadata.browserURL, "https://github.com/retrace")
+    }
+
+    func testFrameQueries_DisplayMetadata_RoundTrips() throws {
+        let segmentID = try createTestSegment()
+        let frame = try insertFrame(
+            makeFrame(
+                segmentID: segmentID,
+                metadata: FrameMetadata(
+                    displayID: 42,
+                    displayStableID: "display:v123:m456:s789",
+                    displayName: "Studio Display"
+                )
+            )
+        )
+
+        let retrieved = try FrameQueries.getByID(db: db!, id: frame.id)
+
+        XCTAssertEqual(retrieved?.metadata.displayID, 42)
+        XCTAssertEqual(retrieved?.metadata.displayStableID, "display:v123:m456:s789")
+        XCTAssertEqual(retrieved?.metadata.displayName, "Studio Display")
     }
 
     func testFrameQueries_Insert_WithNullMetadata_UsesSegmentMetadataWhenAvailable() throws {

--- a/Shared/Models/FilterCriteria.swift
+++ b/Shared/Models/FilterCriteria.swift
@@ -92,6 +92,9 @@ public struct FilterCriteria: Codable, Equatable, Sendable {
     /// Selected data sources (nil = all sources)
     public var selectedSources: Set<FrameSource>?
 
+    /// Internal display scope used by multi-monitor timeline presentation (nil = all displays).
+    public var selectedDisplayStableIDs: Set<String>?
+
     /// How to handle hidden segments
     public var hiddenFilter: HiddenFilter
 
@@ -125,6 +128,7 @@ public struct FilterCriteria: Codable, Equatable, Sendable {
         selectedApps: Set<String>? = nil,
         appFilterMode: AppFilterMode = .include,
         selectedSources: Set<FrameSource>? = nil,
+        selectedDisplayStableIDs: Set<String>? = nil,
         hiddenFilter: HiddenFilter = .hide,
         commentFilter: CommentFilter = .allFrames,
         selectedTags: Set<Int64>? = nil,
@@ -138,6 +142,7 @@ public struct FilterCriteria: Codable, Equatable, Sendable {
         self.selectedApps = selectedApps
         self.appFilterMode = appFilterMode
         self.selectedSources = selectedSources
+        self.selectedDisplayStableIDs = selectedDisplayStableIDs
         self.hiddenFilter = hiddenFilter
         self.commentFilter = commentFilter
         self.selectedTags = selectedTags
@@ -200,6 +205,7 @@ public struct FilterCriteria: Codable, Equatable, Sendable {
         case selectedApps
         case appFilterMode
         case selectedSources
+        case selectedDisplayStableIDs
         case hiddenFilter
         case commentFilter
         case selectedTags
@@ -216,6 +222,7 @@ public struct FilterCriteria: Codable, Equatable, Sendable {
         selectedApps = try container.decodeIfPresent(Set<String>.self, forKey: .selectedApps)
         appFilterMode = try container.decodeIfPresent(AppFilterMode.self, forKey: .appFilterMode) ?? .include
         selectedSources = try container.decodeIfPresent(Set<FrameSource>.self, forKey: .selectedSources)
+        selectedDisplayStableIDs = try container.decodeIfPresent(Set<String>.self, forKey: .selectedDisplayStableIDs)
         hiddenFilter = try container.decodeIfPresent(HiddenFilter.self, forKey: .hiddenFilter) ?? .hide
         commentFilter = try container.decodeIfPresent(CommentFilter.self, forKey: .commentFilter) ?? .allFrames
         selectedTags = try container.decodeIfPresent(Set<Int64>.self, forKey: .selectedTags)
@@ -232,6 +239,7 @@ public struct FilterCriteria: Codable, Equatable, Sendable {
         try container.encodeIfPresent(selectedApps, forKey: .selectedApps)
         try container.encode(appFilterMode, forKey: .appFilterMode)
         try container.encodeIfPresent(selectedSources, forKey: .selectedSources)
+        try container.encodeIfPresent(selectedDisplayStableIDs, forKey: .selectedDisplayStableIDs)
         try container.encode(hiddenFilter, forKey: .hiddenFilter)
         try container.encode(commentFilter, forKey: .commentFilter)
         try container.encodeIfPresent(selectedTags, forKey: .selectedTags)

--- a/Shared/Models/Frame.swift
+++ b/Shared/Models/Frame.swift
@@ -26,6 +26,98 @@ public struct FrameID: Hashable, Codable, Sendable, Identifiable {
 
 // MARK: - Frame Metadata
 
+/// Stable display identity used to correlate the same monitor across hotplug
+/// events where CoreGraphics runtime display IDs may change.
+public struct DisplayIdentity: Codable, Sendable, Equatable, Hashable {
+    public let stableID: String
+    public let runtimeDisplayID: UInt32?
+    public let name: String?
+    public let vendorNumber: UInt32?
+    public let modelNumber: UInt32?
+    public let serialNumber: UInt32?
+    public let width: Int?
+    public let height: Int?
+    public let isMain: Bool?
+
+    public init(
+        stableID: String,
+        runtimeDisplayID: UInt32? = nil,
+        name: String? = nil,
+        vendorNumber: UInt32? = nil,
+        modelNumber: UInt32? = nil,
+        serialNumber: UInt32? = nil,
+        width: Int? = nil,
+        height: Int? = nil,
+        isMain: Bool? = nil
+    ) {
+        self.stableID = stableID
+        self.runtimeDisplayID = runtimeDisplayID
+        self.name = name
+        self.vendorNumber = vendorNumber
+        self.modelNumber = modelNumber
+        self.serialNumber = serialNumber
+        self.width = width
+        self.height = height
+        self.isMain = isMain
+    }
+
+    public static func stableID(
+        vendorNumber: UInt32,
+        modelNumber: UInt32,
+        serialNumber: UInt32,
+        width: Int,
+        height: Int,
+        name: String?
+    ) -> String {
+        if serialNumber != 0 {
+            return "display:v\(vendorNumber):m\(modelNumber):s\(serialNumber)"
+        }
+
+        let normalizedName = name?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .filter { $0.isLetter || $0.isNumber }
+
+        if let normalizedName, !normalizedName.isEmpty {
+            return "display:v\(vendorNumber):m\(modelNumber):name\(normalizedName):\(width)x\(height)"
+        }
+
+        return "display:v\(vendorNumber):m\(modelNumber):\(width)x\(height)"
+    }
+
+    public static func fromRuntimeDisplayID(
+        _ displayID: UInt32,
+        name: String? = nil,
+        width: Int? = nil,
+        height: Int? = nil,
+        isMain: Bool? = nil
+    ) -> DisplayIdentity {
+        let vendorNumber = CGDisplayVendorNumber(displayID)
+        let modelNumber = CGDisplayModelNumber(displayID)
+        let serialNumber = CGDisplaySerialNumber(displayID)
+        let resolvedWidth = width ?? CGDisplayPixelsWide(displayID)
+        let resolvedHeight = height ?? CGDisplayPixelsHigh(displayID)
+        return DisplayIdentity(
+            stableID: stableID(
+                vendorNumber: vendorNumber,
+                modelNumber: modelNumber,
+                serialNumber: serialNumber,
+                width: resolvedWidth,
+                height: resolvedHeight,
+                name: name
+            ),
+            runtimeDisplayID: displayID,
+            name: name,
+            vendorNumber: vendorNumber,
+            modelNumber: modelNumber,
+            serialNumber: serialNumber,
+            width: resolvedWidth,
+            height: resolvedHeight,
+            isMain: isMain
+        )
+    }
+}
+
 /// Coarse-grained reason a frame capture was triggered.
 public enum FrameCaptureTrigger: String, Codable, Sendable, Equatable {
     case window
@@ -56,6 +148,13 @@ public struct FrameMetadata: Codable, Sendable, Equatable {
     /// Display ID that was captured
     public let displayID: UInt32
 
+    /// Stable display identity that should survive monitor unplug/replug when
+    /// CoreGraphics exposes enough hardware metadata.
+    public let displayStableID: String?
+
+    /// Human-readable display name captured alongside the stable ID.
+    public let displayName: String?
+
     /// Mouse position in frame pixel coordinates (top-left origin), when captured.
     public let mousePosition: CGPoint?
 
@@ -67,6 +166,8 @@ public struct FrameMetadata: Codable, Sendable, Equatable {
         redactionReason: String? = nil,
         captureTrigger: FrameCaptureTrigger? = nil,
         displayID: UInt32 = 0,
+        displayStableID: String? = nil,
+        displayName: String? = nil,
         mousePosition: CGPoint? = nil
     ) {
         self.appBundleID = appBundleID
@@ -76,6 +177,8 @@ public struct FrameMetadata: Codable, Sendable, Equatable {
         self.redactionReason = redactionReason
         self.captureTrigger = captureTrigger
         self.displayID = displayID
+        self.displayStableID = displayStableID
+        self.displayName = displayName
         self.mousePosition = mousePosition
     }
 
@@ -214,6 +317,7 @@ public struct VideoSegment: Codable, Sendable, Equatable {
     public let relativePath: String  // Relative to storage root
     public let width: Int
     public let height: Int
+    public let displayStableID: String?
     public let source: FrameSource
 
     public init(
@@ -225,6 +329,7 @@ public struct VideoSegment: Codable, Sendable, Equatable {
         relativePath: String,
         width: Int,
         height: Int,
+        displayStableID: String? = nil,
         source: FrameSource = .native
     ) {
         self.id = id
@@ -235,6 +340,7 @@ public struct VideoSegment: Codable, Sendable, Equatable {
         self.relativePath = relativePath
         self.width = width
         self.height = height
+        self.displayStableID = displayStableID
         self.source = source
     }
 
@@ -281,6 +387,9 @@ public struct FrameVideoInfo: Sendable, Equatable, Codable {
 
     /// Video height in pixels (optional - for aspect ratio calculation)
     public let height: Int?
+
+    /// Stable display identity for the video segment, if known.
+    public let displayStableID: String?
 
     /// Whether the video file has been finalized (processingState = 0)
     /// If true, the video is complete and can be read regardless of file size
@@ -356,6 +465,7 @@ public struct FrameVideoInfo: Sendable, Equatable, Codable {
         frameRate: Double,
         width: Int? = nil,
         height: Int? = nil,
+        displayStableID: String? = nil,
         isVideoFinalized: Bool = true,
         videoReencodedAt: Date? = nil,
         fileSizeBytes: Int64? = nil,
@@ -366,6 +476,7 @@ public struct FrameVideoInfo: Sendable, Equatable, Codable {
         self.frameRate = frameRate
         self.width = width
         self.height = height
+        self.displayStableID = displayStableID
         self.isVideoFinalized = isVideoFinalized
         self.videoReencodedAt = videoReencodedAt
         self.fileSizeBytes = fileSizeBytes
@@ -429,16 +540,31 @@ public struct UnfinalisedVideo: Sendable, Equatable {
     /// Video height in pixels
     public let height: Int
 
+    /// Stable display identity for the unfinalised video, if known.
+    public let displayStableID: String?
+
     /// Resolution string for use as dictionary key
     public var resolutionKey: String {
         "\(width)x\(height)"
     }
 
-    public init(id: Int64, relativePath: String, frameCount: Int, width: Int, height: Int) {
+    public var writerKey: String {
+        "\(displayStableID ?? "legacy")|\(width)x\(height)"
+    }
+
+    public init(
+        id: Int64,
+        relativePath: String,
+        frameCount: Int,
+        width: Int,
+        height: Int,
+        displayStableID: String? = nil
+    ) {
         self.id = id
         self.relativePath = relativePath
         self.frameCount = frameCount
         self.width = width
         self.height = height
+        self.displayStableID = displayStableID
     }
 }

--- a/Shared/Protocols/CaptureProtocol.swift
+++ b/Shared/Protocols/CaptureProtocol.swift
@@ -103,6 +103,10 @@ public struct DisplayInfo: Sendable, Identifiable, Equatable {
     public let scaleFactor: Double  // Retina scale
     public let isMain: Bool
     public let name: String?
+    public let stableID: String?
+    public let vendorNumber: UInt32?
+    public let modelNumber: UInt32?
+    public let serialNumber: UInt32?
 
     public init(
         id: UInt32,
@@ -110,7 +114,11 @@ public struct DisplayInfo: Sendable, Identifiable, Equatable {
         height: Int,
         scaleFactor: Double,
         isMain: Bool,
-        name: String? = nil
+        name: String? = nil,
+        stableID: String? = nil,
+        vendorNumber: UInt32? = nil,
+        modelNumber: UInt32? = nil,
+        serialNumber: UInt32? = nil
     ) {
         self.id = id
         self.width = width
@@ -118,10 +126,29 @@ public struct DisplayInfo: Sendable, Identifiable, Equatable {
         self.scaleFactor = scaleFactor
         self.isMain = isMain
         self.name = name
+        self.stableID = stableID
+        self.vendorNumber = vendorNumber
+        self.modelNumber = modelNumber
+        self.serialNumber = serialNumber
     }
 
     public var nativeWidth: Int { Int(Double(width) * scaleFactor) }
     public var nativeHeight: Int { Int(Double(height) * scaleFactor) }
+
+    public var identity: DisplayIdentity? {
+        guard let stableID else { return nil }
+        return DisplayIdentity(
+            stableID: stableID,
+            runtimeDisplayID: id,
+            name: name,
+            vendorNumber: vendorNumber,
+            modelNumber: modelNumber,
+            serialNumber: serialNumber,
+            width: width,
+            height: height,
+            isMain: isMain
+        )
+    }
 }
 
 /// Capture statistics

--- a/Storage/IncrementalSegmentWriter.swift
+++ b/Storage/IncrementalSegmentWriter.swift
@@ -34,6 +34,7 @@ public actor IncrementalSegmentWriter: SegmentWriter {
     private var encoderInitialized = false
     private var cancelled = false
     private var lastFrameTime: Date?
+    private var displayStableID: String?
 
     init(
         segmentID: VideoSegmentID,
@@ -85,6 +86,7 @@ public actor IncrementalSegmentWriter: SegmentWriter {
         if !encoderInitialized {
             frameWidth = frame.width
             frameHeight = frame.height
+            displayStableID = frame.metadata.displayStableID
 
             try await encoder.initialize(
                 width: frame.width,
@@ -151,7 +153,8 @@ public actor IncrementalSegmentWriter: SegmentWriter {
             fileSizeBytes: size,
             relativePath: relativePath,
             width: frameWidth,
-            height: frameHeight
+            height: frameHeight,
+            displayStableID: displayStableID
         )
     }
 

--- a/Storage/SegmentWriterImpl.swift
+++ b/Storage/SegmentWriterImpl.swift
@@ -25,6 +25,7 @@ public actor SegmentWriterImpl: SegmentWriter {
     private var encoderInitialized = false
     private var cancelled = false
     private var lastFrameTime: Date?
+    private var displayStableID: String?
 
     init(
         segmentID: VideoSegmentID,
@@ -53,6 +54,7 @@ public actor SegmentWriterImpl: SegmentWriter {
         if !encoderInitialized {
             frameWidth = frame.width
             frameHeight = frame.height
+            displayStableID = frame.metadata.displayStableID
 
             // Write directly to output file (no encryption at file level)
             try await encoder.initialize(
@@ -111,7 +113,8 @@ public actor SegmentWriterImpl: SegmentWriter {
             fileSizeBytes: size,
             relativePath: relativePath,
             width: frameWidth,
-            height: frameHeight
+            height: frameHeight,
+            displayStableID: displayStableID
         )
     }
 

--- a/UI/Tests/SearchViewModelAvailableAppsTests.swift
+++ b/UI/Tests/SearchViewModelAvailableAppsTests.swift
@@ -232,7 +232,7 @@ final class SearchViewModelAvailableAppsTests: XCTestCase {
             if condition() {
                 return
             }
-            try? await Task.sleep(nanoseconds: 10_000_000)
+            try? await Task.sleep(for: .milliseconds(10), clock: .continuous)
         }
         XCTFail("Timed out waiting for condition")
     }

--- a/UI/Tests/Timeline/TimelineBlockNavigationTests.swift
+++ b/UI/Tests/Timeline/TimelineBlockNavigationTests.swift
@@ -223,6 +223,18 @@ final class TimelineBlockNavigationTests: XCTestCase {
         XCTAssertEqual(viewModel.currentIndex, 2)
     }
 
+    func testAppBlocksSplitSameAppAcrossDisplays() {
+        let viewModel = makeViewModelWithFrames(
+            ["A", "A", "A"],
+            displayStableIDs: ["display:main", "display:external", "display:main"]
+        )
+
+        XCTAssertEqual(viewModel.appBlocks.count, 3)
+        XCTAssertEqual(viewModel.appBlocks.map(\.startIndex), [0, 1, 2])
+        XCTAssertEqual(viewModel.appBlocks.map(\.endIndex), [0, 1, 2])
+        XCTAssertEqual(viewModel.appBlocks.map(\.displayStableID), ["display:main", "display:external", "display:main"])
+    }
+
     func testNavigateToPreviousBlockStartIgnoresStaleWindowFetchAfterPlayheadMoves() async {
         let baseDate = Date(timeIntervalSince1970: 1_700_000_000)
         let viewModel = makeViewModelWithFrames(["A", "A", "A", "B"], baseDate: baseDate)
@@ -271,11 +283,15 @@ final class TimelineBlockNavigationTests: XCTestCase {
 
     private func makeViewModelWithFrames(
         _ bundleIDs: [String],
-        baseDate: Date = Date(timeIntervalSince1970: 1_700_000_000)
+        baseDate: Date = Date(timeIntervalSince1970: 1_700_000_000),
+        displayStableIDs: [String?]? = nil
     ) -> SimpleTimelineViewModel {
         let viewModel = SimpleTimelineViewModel(coordinator: AppCoordinator())
 
         viewModel.frames = bundleIDs.enumerated().map { index, bundleID in
+            let displayStableID = displayStableIDs.flatMap { ids in
+                index < ids.count ? ids[index] : nil
+            }
             let frame = FrameReference(
                 id: FrameID(value: Int64(index + 1)),
                 timestamp: baseDate.addingTimeInterval(TimeInterval(index)),
@@ -284,7 +300,9 @@ final class TimelineBlockNavigationTests: XCTestCase {
                 metadata: FrameMetadata(
                     appBundleID: bundleID,
                     appName: bundleID,
-                    displayID: 1
+                    displayID: 1,
+                    displayStableID: displayStableID,
+                    displayName: displayStableID
                 )
             )
 

--- a/UI/ViewModels/SearchViewModel.swift
+++ b/UI/ViewModels/SearchViewModel.swift
@@ -1770,7 +1770,7 @@ public class SearchViewModel: ObservableObject {
             guard let self else { return }
 
             do {
-                try await Task.sleep(nanoseconds: otherAppsRefreshDelayNs)
+                try await Task.sleep(for: .nanoseconds(Int64(otherAppsRefreshDelayNs)), clock: .continuous)
             } catch {
                 return
             }

--- a/UI/ViewModels/SimpleTimelineViewModel.swift
+++ b/UI/ViewModels/SimpleTimelineViewModel.swift
@@ -351,14 +351,16 @@ enum CurrentFrameStillDisplayMode: Equatable {
     case none
 }
 
-/// Represents a block of consecutive frames from the same app
+/// Represents a block of consecutive frames from the same app on the same display
 public struct AppBlock: Identifiable, Sendable {
     // Use stable ID based on content to prevent unnecessary view recreation during infinite scroll
     public var id: String {
-        "\(bundleID ?? "nil")_\(startIndex)_\(endIndex)"
+        "\(bundleID ?? "nil")_\(displayStableID ?? displayName ?? "legacy-display")_\(startIndex)_\(endIndex)"
     }
     public let bundleID: String?
     public let appName: String?
+    public let displayStableID: String?
+    public let displayName: String?
     public let startIndex: Int
     public let endIndex: Int
     public let frameCount: Int
@@ -369,6 +371,30 @@ public struct AppBlock: Identifiable, Sendable {
 
     /// Time gap in seconds BEFORE this block (if > 2 minutes, a gap indicator should be shown)
     public let gapBeforeSeconds: TimeInterval?
+
+    public init(
+        bundleID: String?,
+        appName: String?,
+        startIndex: Int,
+        endIndex: Int,
+        frameCount: Int,
+        tagIDs: [Int64],
+        hasComments: Bool,
+        gapBeforeSeconds: TimeInterval?,
+        displayStableID: String? = nil,
+        displayName: String? = nil
+    ) {
+        self.bundleID = bundleID
+        self.appName = appName
+        self.displayStableID = displayStableID
+        self.displayName = displayName
+        self.startIndex = startIndex
+        self.endIndex = endIndex
+        self.frameCount = frameCount
+        self.tagIDs = tagIDs
+        self.hasComments = hasComments
+        self.gapBeforeSeconds = gapBeforeSeconds
+    }
 
     /// Calculate width based on current pixels per frame
     public func width(pixelsPerFrame: CGFloat) -> CGFloat {
@@ -2143,6 +2169,8 @@ public class SimpleTimelineViewModel: ObservableObject {
     private struct SnapshotFrameInput: Sendable {
         let bundleID: String?
         let appName: String?
+        let displayStableID: String?
+        let displayName: String?
         let segmentIDValue: Int64
         let timestamp: Date
         let videoPath: String?
@@ -2201,7 +2229,7 @@ public class SimpleTimelineViewModel: ObservableObject {
         return snapshot
     }
 
-    /// App blocks grouped by consecutive bundle IDs
+    /// App blocks grouped by consecutive bundle IDs and display identity
     /// Note: Since we do server-side filtering, frames already contains only filtered results when filters are active
     public var appBlocks: [AppBlock] {
         appBlockSnapshot.blocks
@@ -2212,6 +2240,8 @@ public class SimpleTimelineViewModel: ObservableObject {
             SnapshotFrameInput(
                 bundleID: timelineFrame.frame.metadata.appBundleID,
                 appName: timelineFrame.frame.metadata.appName,
+                displayStableID: timelineFrame.frame.metadata.displayStableID,
+                displayName: timelineFrame.frame.metadata.displayName,
                 segmentIDValue: timelineFrame.frame.segmentID.value,
                 timestamp: timelineFrame.frame.timestamp,
                 videoPath: timelineFrame.videoInfo?.videoPath
@@ -3499,8 +3529,9 @@ public class SimpleTimelineViewModel: ObservableObject {
         let hasWindowFilter = !(filters.windowNameFilter?.isEmpty ?? true)
         let hasURLFilter = !(filters.browserUrlFilter?.isEmpty ?? true)
         let hasDateRange = !filters.effectiveDateRanges.isEmpty
+        let displayCount = filters.selectedDisplayStableIDs?.count ?? 0
 
-        return "active=\(filters.hasActiveFilters) count=\(filters.activeFilterCount) apps=\(appCount) tags=\(tagCount) appMode=\(filters.appFilterMode.rawValue) hidden=\(filters.hiddenFilter.rawValue) comments=\(filters.commentFilter.rawValue) window=\(hasWindowFilter) url=\(hasURLFilter) date=\(hasDateRange)"
+        return "active=\(filters.hasActiveFilters) count=\(filters.activeFilterCount) apps=\(appCount) tags=\(tagCount) displays=\(displayCount) appMode=\(filters.appFilterMode.rawValue) hidden=\(filters.hiddenFilter.rawValue) comments=\(filters.commentFilter.rawValue) window=\(hasWindowFilter) url=\(hasURLFilter) date=\(hasDateRange)"
     }
 
     private func logCmdFPlayheadState(
@@ -4033,7 +4064,9 @@ public class SimpleTimelineViewModel: ObservableObject {
             targetIndex = findClosestFrameIndex(to: targetDate)
         }
 
-        guard requestStillCurrent?() ?? true else { return nil }
+        // Replacing the loaded window can legitimately change currentTimelineFrame
+        // before the explicit navigation below; the stale-request checks above
+        // cover all async suspension points before this synchronous apply.
         navigateToFrame(targetIndex)
         return targetIndex
     }
@@ -4293,6 +4326,54 @@ public class SimpleTimelineViewModel: ObservableObject {
         }
 
         setLoadingState(false, reason: "reloadFramesAroundTimestamp.complete")
+    }
+
+    /// Restrict this timeline instance to a single connected display.
+    /// Used by multi-monitor companion windows; this is intentionally not counted
+    /// as a user-visible filter badge.
+    public func applyDisplayScope(stableID: String?) {
+        let normalizedStableID = stableID?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let displayIDs: Set<String>?
+        if let normalizedStableID, !normalizedStableID.isEmpty {
+            displayIDs = [normalizedStableID]
+        } else {
+            displayIDs = nil
+        }
+
+        let didChangeScope =
+            filterCriteria.selectedDisplayStableIDs != displayIDs ||
+            pendingFilterCriteria.selectedDisplayStableIDs != displayIDs
+        var applied = normalizedTimelineFilterCriteria(filterCriteria)
+        var pending = normalizedTimelineFilterCriteria(pendingFilterCriteria)
+        applied.selectedDisplayStableIDs = displayIDs
+        pending.selectedDisplayStableIDs = displayIDs
+
+        filterCriteria = applied
+        pendingFilterCriteria = pending
+        if didChangeScope {
+            requiresFullReloadOnNextRefresh = true
+        }
+    }
+
+    /// Sync the playhead to the closest frame for this view model's display scope.
+    public func synchronizeToTimestamp(_ timestamp: Date) async {
+        guard !isLoading else { return }
+
+        if !frames.isEmpty {
+            let closestIndex = findClosestFrameIndex(to: timestamp)
+            let closestTimestamp = frames[closestIndex].frame.timestamp
+            let diff = abs(closestTimestamp.timeIntervalSince(timestamp))
+            if diff <= 600 {
+                if currentIndex != closestIndex {
+                    currentIndex = closestIndex
+                    loadImageIfNeeded()
+                }
+                return
+            }
+        }
+
+        await reloadFramesAroundTimestamp(timestamp, refreshPresentation: true)
     }
 
     // MARK: - Frame Selection & Deletion
@@ -6941,6 +7022,8 @@ public class SimpleTimelineViewModel: ObservableObject {
         var segmentBoundaries: [Int] = []
 
         var currentBundleID: String? = frameList[0].bundleID
+        var currentDisplayStableID: String? = frameList[0].displayStableID
+        var currentDisplayName: String? = frameList[0].displayName
         var blockStartIndex = 0
         var currentBlockIndex = 0
         var gapBeforeCurrentBlock: TimeInterval? = nil
@@ -6956,6 +7039,7 @@ public class SimpleTimelineViewModel: ObservableObject {
 
             let timelineFrame = frameList[index]
             let frameBundleID = timelineFrame.bundleID
+            let frameDisplayStableID = timelineFrame.displayStableID
 
             // Track boundary when video path changes from previous frame.
             if index > 0 {
@@ -6982,8 +7066,9 @@ public class SimpleTimelineViewModel: ObservableObject {
 
             let hasSignificantGap = gapDuration >= Self.minimumGapThreshold
             let appChanged = frameBundleID != currentBundleID
+            let displayChanged = frameDisplayStableID != currentDisplayStableID
 
-            if (appChanged || hasSignificantGap) && index > 0 {
+            if (appChanged || displayChanged || hasSignificantGap) && index > 0 {
                 let filteredTagIDs = currentBlockTagIDs
                     .filter { tagID in
                         guard let hiddenTagID else { return true }
@@ -6999,11 +7084,15 @@ public class SimpleTimelineViewModel: ObservableObject {
                     frameCount: index - blockStartIndex,
                     tagIDs: filteredTagIDs,
                     hasComments: currentBlockHasComments,
-                    gapBeforeSeconds: gapBeforeCurrentBlock
+                    gapBeforeSeconds: gapBeforeCurrentBlock,
+                    displayStableID: currentDisplayStableID,
+                    displayName: currentDisplayName
                 ))
 
                 currentBlockIndex += 1
                 currentBundleID = frameBundleID
+                currentDisplayStableID = frameDisplayStableID
+                currentDisplayName = timelineFrame.displayName
                 blockStartIndex = index
                 gapBeforeCurrentBlock = hasSignificantGap ? gapDuration : nil
                 currentBlockTagIDs.removeAll(keepingCapacity: true)
@@ -7036,7 +7125,9 @@ public class SimpleTimelineViewModel: ObservableObject {
             frameCount: frameList.count - blockStartIndex,
             tagIDs: finalFilteredTagIDs,
             hasComments: currentBlockHasComments,
-            gapBeforeSeconds: gapBeforeCurrentBlock
+            gapBeforeSeconds: gapBeforeCurrentBlock,
+            displayStableID: currentDisplayStableID,
+            displayName: currentDisplayName
         ))
 
         return AppBlockSnapshot(
@@ -7543,7 +7634,9 @@ public class SimpleTimelineViewModel: ObservableObject {
 
     /// Clear all pending filters
     public func clearPendingFilters() {
+        let displayScope = filterCriteria.selectedDisplayStableIDs
         pendingFilterCriteria = .none
+        pendingFilterCriteria.selectedDisplayStableIDs = displayScope
         Log.debug("[Filter] Cleared pending filters", category: .ui)
     }
 
@@ -7617,8 +7710,11 @@ public class SimpleTimelineViewModel: ObservableObject {
     /// Clear filter state without triggering a reload
     /// Used by goToNow() which handles its own reload
     private func clearFilterState() {
+        let displayScope = filterCriteria.selectedDisplayStableIDs ?? pendingFilterCriteria.selectedDisplayStableIDs
         filterCriteria = .none
         pendingFilterCriteria = .none
+        filterCriteria.selectedDisplayStableIDs = displayScope
+        pendingFilterCriteria.selectedDisplayStableIDs = displayScope
         Log.debug("[Filter] Cleared all filters", category: .ui)
 
         // Save (clear) filter criteria cache immediately
@@ -7664,8 +7760,11 @@ public class SimpleTimelineViewModel: ObservableObject {
         Log.info("[Peek] Cached filtered state: \(frames.count) frames, index=\(currentIndex)", category: .ui)
 
         // Clear filters and load unfiltered timeline centered on current timestamp
+        let displayScope = filterCriteria.selectedDisplayStableIDs
         filterCriteria = .none
         pendingFilterCriteria = .none
+        filterCriteria.selectedDisplayStableIDs = displayScope
+        pendingFilterCriteria.selectedDisplayStableIDs = displayScope
         isPeeking = true
 
         Task {
@@ -8331,20 +8430,22 @@ public class SimpleTimelineViewModel: ObservableObject {
         if normalizedPendingCriteria != pendingFilterCriteria {
             pendingFilterCriteria = normalizedPendingCriteria
         }
+        var criteriaForCache = normalizedPendingCriteria
+        criteriaForCache.selectedDisplayStableIDs = nil
 
-        Log.debug("[FilterCache] saveFilterCriteria() called - pending.selectedApps=\(String(describing: normalizedPendingCriteria.selectedApps)), pending.hasActiveFilters=\(normalizedPendingCriteria.hasActiveFilters)", category: .ui)
+        Log.debug("[FilterCache] saveFilterCriteria() called - pending.selectedApps=\(String(describing: criteriaForCache.selectedApps)), pending.hasActiveFilters=\(criteriaForCache.hasActiveFilters)", category: .ui)
         // If no filters are active in pending, clear any cached filters to avoid restoring stale state
-        guard normalizedPendingCriteria.hasActiveFilters else {
+        guard criteriaForCache.hasActiveFilters else {
             Log.debug("[FilterCache] No active pending filters, clearing cache", category: .ui)
             clearCachedFilterCriteria()
             return
         }
 
         do {
-            let data = try JSONEncoder().encode(normalizedPendingCriteria)
+            let data = try JSONEncoder().encode(criteriaForCache)
             UserDefaults.standard.set(data, forKey: Self.cachedFilterCriteriaKey)
             UserDefaults.standard.set(Date().timeIntervalSince1970, forKey: Self.cachedFilterSavedAtKey)
-            Log.debug("[FilterCache] Saved pending filter criteria with selectedApps=\(String(describing: normalizedPendingCriteria.selectedApps))", category: .ui)
+            Log.debug("[FilterCache] Saved pending filter criteria with selectedApps=\(String(describing: criteriaForCache.selectedApps))", category: .ui)
         } catch {
             Log.warning("[FilterCache] Failed to save filter criteria: \(error)", category: .ui)
         }

--- a/UI/Views/FullscreenTimeline/SimpleTimelineView.swift
+++ b/UI/Views/FullscreenTimeline/SimpleTimelineView.swift
@@ -28,14 +28,21 @@ public struct SimpleTimelineView: View {
     @AppStorage("showFrameIDs", store: timelineSettingsStore) private var showFrameCard = SettingsDefaults.showFrameIDs
 
     let coordinator: AppCoordinator
+    let showsTimelineChrome: Bool
     let onClose: () -> Void
 
     // MARK: - Initialization
 
     /// Initialize with an external view model (scroll events handled by TimelineWindowController)
-    public init(coordinator: AppCoordinator, viewModel: SimpleTimelineViewModel, onClose: @escaping () -> Void) {
+    public init(
+        coordinator: AppCoordinator,
+        viewModel: SimpleTimelineViewModel,
+        showsTimelineChrome: Bool = true,
+        onClose: @escaping () -> Void
+    ) {
         self.coordinator = coordinator
         self.viewModel = viewModel
+        self.showsTimelineChrome = showsTimelineChrome
         self.onClose = onClose
     }
 
@@ -75,38 +82,40 @@ public struct SimpleTimelineView: View {
                 // Search-result highlights should sit above the frame, but below timeline controls/tape.
                 searchHighlightOverlay(containerSize: geometry.size, actualFrameRect: actualFrameRect)
 
-                // Bottom blur + gradient backdrop (behind timeline controls)
-                VStack {
-                    Spacer()
-                    // Blur with built-in tint (NSVisualEffectView needs content to blur)
-                    PureBlurView(radius: 50)
-                        .frame(height: TimelineScaleFactor.blurBackdropHeight)
-                        .mask(
-                            LinearGradient(
-                                stops: [
-                                    .init(color: Color.white.opacity(0.0), location: 0.0),
-                                    .init(color: Color.white.opacity(0.03), location: 0.1),
-                                    .init(color: Color.white.opacity(0.08), location: 0.2),
-                                    .init(color: Color.white.opacity(0.15), location: 0.3),
-                                    .init(color: Color.white.opacity(0.35), location: 0.4),
-                                    .init(color: Color.white.opacity(0.6), location: 0.5),
-                                    .init(color: Color.white.opacity(0.85), location: 0.6),
-                                    .init(color: Color.white.opacity(0.95), location: 0.7),
-                                    .init(color: Color.white.opacity(1.0), location: 0.8),
-                                    .init(color: Color.white.opacity(0.85), location: 1.0)
-                                ],
-                                startPoint: .top,
-                                endPoint: .bottom
+                if showsTimelineChrome {
+                    // Bottom blur + gradient backdrop (behind timeline controls)
+                    VStack {
+                        Spacer()
+                        // Blur with built-in tint (NSVisualEffectView needs content to blur)
+                        PureBlurView(radius: 50)
+                            .frame(height: TimelineScaleFactor.blurBackdropHeight)
+                            .mask(
+                                LinearGradient(
+                                    stops: [
+                                        .init(color: Color.white.opacity(0.0), location: 0.0),
+                                        .init(color: Color.white.opacity(0.03), location: 0.1),
+                                        .init(color: Color.white.opacity(0.08), location: 0.2),
+                                        .init(color: Color.white.opacity(0.15), location: 0.3),
+                                        .init(color: Color.white.opacity(0.35), location: 0.4),
+                                        .init(color: Color.white.opacity(0.6), location: 0.5),
+                                        .init(color: Color.white.opacity(0.85), location: 0.6),
+                                        .init(color: Color.white.opacity(0.95), location: 0.7),
+                                        .init(color: Color.white.opacity(1.0), location: 0.8),
+                                        .init(color: Color.white.opacity(0.85), location: 1.0)
+                                    ],
+                                    startPoint: .top,
+                                    endPoint: .bottom
+                                )
                             )
-                        )
+                    }
+                    .allowsHitTesting(false)
+                    .offset(y: viewModel.areControlsHidden ? TimelineScaleFactor.hiddenControlsOffset : (viewModel.isTapeHidden ? TimelineScaleFactor.hiddenControlsOffset : 0))
+                    .opacity(viewModel.areControlsHidden || viewModel.isDraggingZoomRegion ? 0 : 1)
                 }
-                .allowsHitTesting(false)
-                .offset(y: viewModel.areControlsHidden ? TimelineScaleFactor.hiddenControlsOffset : (viewModel.isTapeHidden ? TimelineScaleFactor.hiddenControlsOffset : 0))
-                .opacity(viewModel.areControlsHidden || viewModel.isDraggingZoomRegion ? 0 : 1)
 
                 // Dismiss overlay for date search panel (Cmd+G) - clicking outside closes it
                 // Must be BEFORE TimelineTapeView in ZStack so it's behind the panel
-                if viewModel.isDateSearchActive && !viewModel.isCalendarPickerVisible {
+                if showsTimelineChrome && viewModel.isDateSearchActive && !viewModel.isCalendarPickerVisible {
                     Color.clear
                         .contentShape(Rectangle())
                         .ignoresSafeArea()
@@ -117,7 +126,7 @@ public struct SimpleTimelineView: View {
 
                 // Dismiss overlay for calendar picker - clicking outside closes it
                 // Must be BEFORE TimelineTapeView in ZStack so it's behind the picker
-                if viewModel.isCalendarPickerVisible {
+                if showsTimelineChrome && viewModel.isCalendarPickerVisible {
                     Color.clear
                         .contentShape(Rectangle())
                         .ignoresSafeArea()
@@ -129,7 +138,7 @@ public struct SimpleTimelineView: View {
                 }
 
                 // Dismiss overlay for zoom slider - clicking outside closes it
-                if viewModel.isZoomSliderExpanded {
+                if showsTimelineChrome && viewModel.isZoomSliderExpanded {
                     Color.clear
                         .contentShape(Rectangle())
                         .ignoresSafeArea()
@@ -140,21 +149,23 @@ public struct SimpleTimelineView: View {
                         }
                 }
 
-                // Timeline tape overlay at bottom
-                VStack {
-                    Spacer()
-                    TimelineTapeView(
-                        viewModel: viewModel,
-                        width: geometry.size.width,
-                        coordinator: coordinator
-                    )
-                    .padding(.bottom, TimelineScaleFactor.tapeBottomPadding)
+                if showsTimelineChrome {
+                    // Timeline tape overlay at bottom
+                    VStack {
+                        Spacer()
+                        TimelineTapeView(
+                            viewModel: viewModel,
+                            width: geometry.size.width,
+                            coordinator: coordinator
+                        )
+                        .padding(.bottom, TimelineScaleFactor.tapeBottomPadding)
+                    }
+                    .offset(y: viewModel.areControlsHidden ? TimelineScaleFactor.hiddenControlsOffset : (viewModel.isTapeHidden ? TimelineScaleFactor.hiddenControlsOffset : 0))
+                    .opacity(viewModel.areControlsHidden || viewModel.isDraggingZoomRegion ? 0 : 1)
                 }
-                .offset(y: viewModel.areControlsHidden ? TimelineScaleFactor.hiddenControlsOffset : (viewModel.isTapeHidden ? TimelineScaleFactor.hiddenControlsOffset : 0))
-                .opacity(viewModel.areControlsHidden || viewModel.isDraggingZoomRegion ? 0 : 1)
 
                 // Persistent controls toggle button (stays visible when controls are hidden)
-                if viewModel.areControlsHidden {
+                if showsTimelineChrome && viewModel.areControlsHidden {
                     VStack {
                         Spacer()
                         HStack {
@@ -167,29 +178,44 @@ public struct SimpleTimelineView: View {
                     .transition(.opacity.animation(.easeInOut(duration: 0.2).delay(0.1)))
                 }
 
-                // Debug frame card, OCR status indicator, and developer actions menu (top-left)
-                VStack {
-                    HStack(spacing: 8) {
-                        if showFrameCard {
-                            DebugFrameIDBadge(viewModel: viewModel)
+                if showsTimelineChrome {
+                    // Debug frame card, OCR status indicator, and developer actions menu (top-left)
+                    VStack {
+                        HStack(spacing: 8) {
+                            CurrentDisplayBadge(viewModel: viewModel)
+                            if showFrameCard {
+                                DebugFrameIDBadge(viewModel: viewModel)
+                            }
+                            // OCR status indicator (only visible when OCR is in progress)
+                            OCRStatusIndicator(viewModel: viewModel)
+                            #if DEBUG
+                            DeveloperActionsMenu(viewModel: viewModel, onClose: onClose)
+                            #endif
+                            Spacer()
+                                .allowsHitTesting(false)
                         }
-                        // OCR status indicator (only visible when OCR is in progress)
-                        OCRStatusIndicator(viewModel: viewModel)
-                        #if DEBUG
-                        DeveloperActionsMenu(viewModel: viewModel, onClose: onClose)
-                        #endif
                         Spacer()
                             .allowsHitTesting(false)
                     }
-                    Spacer()
-                        .allowsHitTesting(false)
+                    .padding(.spacingL)
+                    .offset(y: viewModel.areControlsHidden ? TimelineScaleFactor.closeButtonHiddenYOffset : 0)
+                    .opacity(viewModel.areControlsHidden || viewModel.isDraggingZoomRegion ? 0 : 1)
+                } else {
+                    VStack {
+                        HStack {
+                            CurrentDisplayBadge(viewModel: viewModel)
+                            Spacer()
+                                .allowsHitTesting(false)
+                        }
+                        Spacer()
+                            .allowsHitTesting(false)
+                    }
+                    .padding(.spacingL)
+                    .allowsHitTesting(false)
                 }
-                .padding(.spacingL)
-                .offset(y: viewModel.areControlsHidden ? TimelineScaleFactor.closeButtonHiddenYOffset : 0)
-                .opacity(viewModel.areControlsHidden || viewModel.isDraggingZoomRegion ? 0 : 1)
 
                 #if DEBUG
-                if viewModel.showBrowserURLDebugWindow {
+                if showsTimelineChrome && viewModel.showBrowserURLDebugWindow {
                     DebugBrowserURLWindow(
                         browserURL: currentBrowserURLForDebugWindow,
                         panelPosition: $browserURLDebugWindowPosition,
@@ -202,7 +228,7 @@ public struct SimpleTimelineView: View {
                 #endif
 
                 // Reset zoom button (top center)
-                if viewModel.isFrameZoomed {
+                if showsTimelineChrome && viewModel.isFrameZoomed {
                     VStack {
                         ResetZoomButton(viewModel: viewModel)
                             .padding(.top, 12) // Extra margin for MacBook notch
@@ -216,7 +242,7 @@ public struct SimpleTimelineView: View {
                 }
 
                 // Peek mode banner (top center, below reset zoom if both visible)
-                if viewModel.isPeeking {
+                if showsTimelineChrome && viewModel.isPeeking {
                     VStack {
                         PeekModeBanner(viewModel: viewModel)
                             .padding(.top, viewModel.isFrameZoomed ? 60 : 12) // Below reset zoom button if visible
@@ -230,7 +256,7 @@ public struct SimpleTimelineView: View {
                 }
 
                 // Persistent redaction reason banner (top center)
-                if let redactionContext = currentRedactionContext {
+                if showsTimelineChrome, let redactionContext = currentRedactionContext {
                     VStack {
                         RedactionReasonBanner(
                             reason: redactionContext.reason,
@@ -250,18 +276,20 @@ public struct SimpleTimelineView: View {
                 }
 
                 // Top-right controls (in-frame search + close)
-                VStack {
-                    HStack {
+                if showsTimelineChrome {
+                    VStack {
+                        HStack {
+                            Spacer()
+                                .allowsHitTesting(false)
+                            topRightControls
+                        }
                         Spacer()
                             .allowsHitTesting(false)
-                        topRightControls
                     }
-                    Spacer()
-                        .allowsHitTesting(false)
+                    .padding(.spacingL)
+                    .padding(.top, 12) // Match ResetZoomButton vertical row alignment
+                    .zIndex(100)
                 }
-                .padding(.spacingL)
-                .padding(.top, 12) // Match ResetZoomButton vertical row alignment
-                .zIndex(100)
 
 
                 // Loading overlay
@@ -277,7 +305,7 @@ public struct SimpleTimelineView: View {
                 }
 
                 // Delete confirmation dialog
-                if viewModel.showDeleteConfirmation {
+                if showsTimelineChrome && viewModel.showDeleteConfirmation {
                     DeleteConfirmationDialog(
                         segmentFrameCount: viewModel.selectedSegmentFrameCount,
                         onDeleteFrame: {
@@ -293,15 +321,21 @@ public struct SimpleTimelineView: View {
                 }
 
                 // Search overlay (Cmd+K) - uses persistent searchViewModel to preserve results
-                searchOverlay
+                if showsTimelineChrome {
+                    searchOverlay
+                }
 
                 // OCR debug overlay (dev setting)
-                ocrDebugOverlay(containerSize: geometry.size, actualFrameRect: actualFrameRect)
+                if showsTimelineChrome {
+                    ocrDebugOverlay(containerSize: geometry.size, actualFrameRect: actualFrameRect)
+                }
 
-                topHintOverlay(shouldRenderSearchHighlightControlsHint: shouldRenderSearchHighlightControlsHint)
+                if showsTimelineChrome {
+                    topHintOverlay(shouldRenderSearchHighlightControlsHint: shouldRenderSearchHighlightControlsHint)
+                }
 
                 // Filter panel (floating, anchored to filter button position)
-                if viewModel.isFilterPanelVisible {
+                if showsTimelineChrome && viewModel.isFilterPanelVisible {
                     // Dismiss overlay for filter panel and any open dropdown
                     Color.black.opacity(0.001)
                         .ignoresSafeArea()
@@ -335,7 +369,7 @@ public struct SimpleTimelineView: View {
 
                 // Timeline segment context menu (for right-click on timeline tape)
                 // Placed at the end of ZStack to ensure it renders above all other content
-                if viewModel.showTimelineContextMenu {
+                if showsTimelineChrome && viewModel.showTimelineContextMenu {
                     TimelineSegmentContextMenu(
                         viewModel: viewModel,
                         isPresented: $viewModel.showTimelineContextMenu,
@@ -344,7 +378,7 @@ public struct SimpleTimelineView: View {
                     )
                 }
 
-                if isCommentSubmenuMounted {
+                if showsTimelineChrome && isCommentSubmenuMounted {
                     Color.black.opacity(0.35)
                         .opacity(commentSubmenuVisibility)
                         .ignoresSafeArea()
@@ -366,7 +400,7 @@ public struct SimpleTimelineView: View {
                 }
 
                 // Toast feedback overlay (centered, larger for errors)
-                if viewModel.toastMessage != nil {
+                if showsTimelineChrome && viewModel.toastMessage != nil {
                     let isErrorToast = viewModel.toastTone == .error
                     let toastAccentColor = isErrorToast ? Color.red : Color.green
 
@@ -395,7 +429,7 @@ public struct SimpleTimelineView: View {
                 }
 
                 // Delete undo action banner (interactive)
-                if let undoMessage = viewModel.pendingDeleteUndoMessage {
+                if showsTimelineChrome, let undoMessage = viewModel.pendingDeleteUndoMessage {
                     VStack {
                         HStack(spacing: 10) {
                             Image(systemName: "trash.fill")
@@ -6107,6 +6141,57 @@ struct OCRDebugOverlay: View {
         .background(Color.black.opacity(0.7))
         .cornerRadius(6)
         .position(x: actualFrameRect.maxX - 70, y: actualFrameRect.origin.y + 50)
+    }
+}
+
+// MARK: - Current Display Badge
+
+/// Shows which physical display the current historical frame came from.
+struct CurrentDisplayBadge: View {
+    @ObservedObject var viewModel: SimpleTimelineViewModel
+
+    private var displayLabel: String? {
+        guard let metadata = viewModel.currentFrame?.metadata else { return nil }
+
+        if let displayName = metadata.displayName?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           !displayName.isEmpty {
+            return displayName
+        }
+
+        guard metadata.displayID > 0 else { return nil }
+        return "Display \(metadata.displayID)"
+    }
+
+    private var displayHelpText: String {
+        guard let label = displayLabel else { return "Display" }
+        if let stableID = viewModel.currentFrame?.metadata.displayStableID,
+           !stableID.isEmpty {
+            return "\(label)\n\(stableID)"
+        }
+        return label
+    }
+
+    var body: some View {
+        if let displayLabel {
+            HStack(spacing: 6) {
+                Image(systemName: "display")
+                    .font(.system(size: 11 * TimelineScaleFactor.current, weight: .semibold))
+                    .foregroundColor(.white.opacity(0.72))
+
+                Text(displayLabel)
+                    .font(.system(size: 12 * TimelineScaleFactor.current, weight: .medium))
+                    .foregroundColor(.white.opacity(0.86))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .frame(maxWidth: 132 * TimelineScaleFactor.current, alignment: .leading)
+            }
+            .padding(.horizontal, 10 * TimelineScaleFactor.current)
+            .padding(.vertical, 6 * TimelineScaleFactor.current)
+            .timelineGlassSurface(.chip, cornerRadius: 8 * TimelineScaleFactor.current)
+            .help(displayHelpText)
+            .transition(.opacity.combined(with: .scale(scale: 0.94)))
+        }
     }
 }
 

--- a/UI/Views/FullscreenTimeline/TimelineTapeView.swift
+++ b/UI/Views/FullscreenTimeline/TimelineTapeView.swift
@@ -26,7 +26,7 @@ struct TimelineBlockIndicatorPresentation: Equatable {
 }
 
 /// Timeline tape view that scrolls horizontally with a fixed center playhead
-/// Groups consecutive frames by app and displays app icons
+/// Groups consecutive frames by app/display and displays app icons
 public struct TimelineTapeView: View {
 
     // MARK: - Properties
@@ -352,6 +352,7 @@ public struct TimelineTapeView: View {
                 hoveredBlockID = hovering ? block.id : (hoveredBlockID == block.id ? nil : hoveredBlockID)
             }
         }
+        .help(blockHelpText(for: block))
         .opacity(isHidingBlock ? 0.12 : 1.0)
         .animation(.easeInOut(duration: 0.16), value: collapseFactor)
     }
@@ -536,6 +537,15 @@ public struct TimelineTapeView: View {
             return Color.segmentColor(for: bundleID)
         }
         return Color.gray.opacity(0.5)
+    }
+
+    private func blockHelpText(for block: AppBlock) -> String {
+        let appText = block.appName ?? block.bundleID ?? "Unknown app"
+        guard let displayName = block.displayName?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !displayName.isEmpty else {
+            return appText
+        }
+        return "\(appText) on \(displayName)"
     }
 
     private func appIcon(for bundleID: String) -> some View {

--- a/UI/Views/FullscreenTimeline/TimelineWindowController.swift
+++ b/UI/Views/FullscreenTimeline/TimelineWindowController.swift
@@ -1,5 +1,6 @@
 import AppKit
 import SwiftUI
+import Combine
 import App
 import Shared
 import CoreGraphics
@@ -34,6 +35,18 @@ public class TimelineWindowController: NSObject {
     private var timelineViewModel: SimpleTimelineViewModel?
     private var pendingTimelineViewModelWaiters: [CheckedContinuation<SimpleTimelineViewModel, Never>] = []
     private var hostingView: NSView?
+    private var primaryPresentationDisplayID: CGDirectDisplayID?
+    private struct CompanionTimelinePresentation {
+        let runtimeDisplayID: CGDirectDisplayID
+        let stableDisplayID: String
+        let displayName: String?
+        let window: NSWindow
+        let hostingView: NSView
+        let viewModel: SimpleTimelineViewModel
+    }
+    private var companionPresentations: [CGDirectDisplayID: CompanionTimelinePresentation] = [:]
+    private var companionSyncCancellable: AnyCancellable?
+    private var companionSyncTask: Task<Void, Never>?
     private var deferredHostingViewDetachTask: Task<Void, Never>?
     private var tapeShowAnimationTask: Task<Void, Never>?
     private var liveModeCaptureTask: Task<Void, Never>?
@@ -652,6 +665,38 @@ public class TimelineWindowController: NSObject {
         return "[" + displayIDs.sorted().map(String.init).joined(separator: ",") + "]"
     }
 
+    private static func runtimeDisplayID(for screen: NSScreen?) -> CGDirectDisplayID? {
+        screen?.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID
+    }
+
+    private static func displayName(for displayID: CGDirectDisplayID) -> String {
+        displayID == CGMainDisplayID() ? "Main Display" : "Display \(displayID)"
+    }
+
+    private static func displayIdentity(for screen: NSScreen) -> DisplayIdentity? {
+        guard let displayID = runtimeDisplayID(for: screen) else { return nil }
+        return DisplayIdentity.fromRuntimeDisplayID(
+            displayID,
+            name: displayName(for: displayID),
+            width: CGDisplayPixelsWide(displayID),
+            height: CGDisplayPixelsHigh(displayID),
+            isMain: displayID == CGMainDisplayID()
+        )
+    }
+
+    private func applyPrimaryDisplayScope(on screen: NSScreen, to viewModel: SimpleTimelineViewModel) {
+        guard let identity = Self.displayIdentity(for: screen) else {
+            viewModel.applyDisplayScope(stableID: nil)
+            return
+        }
+
+        viewModel.applyDisplayScope(stableID: identity.stableID)
+        Log.info(
+            "[TIMELINE-MULTI-DISPLAY] Primary timeline scoped displayName=\(identity.name ?? "nil") runtimeID=\(identity.runtimeDisplayID.map(String.init) ?? "nil") stableID=\(identity.stableID)",
+            category: .ui
+        )
+    }
+
     private func stopObservingApplicationActivation() {
         guard let workspaceActivationObserver else { return }
         NSWorkspace.shared.notificationCenter.removeObserver(workspaceActivationObserver)
@@ -954,6 +999,7 @@ public class TimelineWindowController: NSObject {
             window.ignoresMouseEvents = true
             window.orderOut(nil)
         }
+        closeCompanionTimelines()
         presentationState = .hidden
         Self.setEmergencyTimelineVisible(false)
         lastHiddenAt = Date()
@@ -1432,6 +1478,7 @@ public class TimelineWindowController: NSObject {
 
         // Check if we have a prepared metadata state ready
         if isPrepared, let viewModel = timelineViewModel {
+            applyPrimaryDisplayScope(on: targetScreen, to: viewModel)
             mountPresentationIfNeeded(
                 on: targetScreen,
                 coordinator: coordinator,
@@ -1464,6 +1511,7 @@ public class TimelineWindowController: NSObject {
         // Fallback: Create presentation and view model from scratch (prerender disabled or unavailable).
         let viewModel = SimpleTimelineViewModel(coordinator: coordinator)
         setTimelineViewModel(viewModel)
+        applyPrimaryDisplayScope(on: targetScreen, to: viewModel)
         prepareLiveModeState(shouldUseLiveMode: shouldUseLiveMode, viewModel: viewModel)
         viewModel.isTapeHidden = true
         tapeShowAnimationTask?.cancel()
@@ -1547,6 +1595,12 @@ public class TimelineWindowController: NSObject {
             DispatchQueue.main.async { [weak hostingView] in
                 hostingView?.layoutSubtreeIfNeeded()
             }
+        }
+        if let primaryViewModel = timelineViewModel {
+            showCompanionTimelinesIfNeeded(
+                coordinator: coordinator,
+                primaryViewModel: primaryViewModel
+            )
         }
         let openElapsedMs = (CFAbsoluteTimeGetCurrent() - showStartTime) * 1000
         Log.recordLatency(
@@ -1674,6 +1728,17 @@ public class TimelineWindowController: NSObject {
             NSApp.activate(ignoringOtherApps: true)
             self.window?.makeKey()
         }
+    }
+
+    private func showCompanionTimelinesIfNeeded(
+        coordinator: AppCoordinator,
+        primaryViewModel: SimpleTimelineViewModel
+    ) {
+        showCompanionTimelines(
+            excludingPrimaryDisplayID: primaryPresentationDisplayID,
+            coordinator: coordinator,
+            primaryViewModel: primaryViewModel
+        )
     }
 
     /// Hide the timeline overlay
@@ -1950,6 +2015,7 @@ public class TimelineWindowController: NSObject {
         viewModel: SimpleTimelineViewModel
     ) {
         if let window {
+            primaryPresentationDisplayID = Self.runtimeDisplayID(for: screen)
             if window.frame != screen.frame {
                 window.setFrame(screen.frame, display: false)
             }
@@ -1985,6 +2051,139 @@ public class TimelineWindowController: NSObject {
 
         self.window = window
         self.hostingView = hostingView
+        self.primaryPresentationDisplayID = Self.runtimeDisplayID(for: screen)
+    }
+
+    private func showCompanionTimelines(
+        excludingPrimaryDisplayID primaryDisplayID: CGDirectDisplayID?,
+        coordinator: AppCoordinator,
+        primaryViewModel: SimpleTimelineViewModel
+    ) {
+        guard let coordinatorWrapper else { return }
+
+        closeCompanionTimelines()
+
+        let companionScreens = NSScreen.screens.filter { screen in
+            guard let displayID = Self.runtimeDisplayID(for: screen) else { return false }
+            return displayID != primaryDisplayID
+        }
+
+        guard !companionScreens.isEmpty else {
+            Log.info(
+                "[TIMELINE-MULTI-DISPLAY] No companion screens available screenCount=\(NSScreen.screens.count) primaryDisplayID=\(primaryDisplayID.map(String.init) ?? "nil")",
+                category: .ui
+            )
+            return
+        }
+
+        for screen in companionScreens {
+            guard let displayID = Self.runtimeDisplayID(for: screen),
+                  let identity = Self.displayIdentity(for: screen) else {
+                continue
+            }
+
+            let companionViewModel = SimpleTimelineViewModel(coordinator: coordinator)
+            companionViewModel.applyDisplayScope(stableID: identity.stableID)
+            companionViewModel.areControlsHidden = true
+            companionViewModel.isTapeHidden = true
+            companionViewModel.setPresentationWorkEnabled(true, reason: "timeline companion show")
+
+            let companionWindow = createWindow(for: screen)
+            companionWindow.ignoresMouseEvents = true
+            companionWindow.alphaValue = 1
+            companionWindow.collectionBehavior.remove(.moveToActiveSpace)
+            companionWindow.collectionBehavior.insert(.canJoinAllSpaces)
+            companionWindow.collectionBehavior.insert(.fullScreenAuxiliary)
+
+            let timelineView = SimpleTimelineView(
+                coordinator: coordinator,
+                viewModel: companionViewModel,
+                showsTimelineChrome: false,
+                onClose: { [weak self] in
+                    self?.hide()
+                }
+            )
+            .environmentObject(coordinatorWrapper)
+
+            let hostingView = FirstMouseHostingView(rootView: timelineView)
+            hostingView.frame = companionWindow.contentView?.bounds ?? .zero
+            hostingView.autoresizingMask = [.width, .height]
+            companionWindow.contentView?.addSubview(hostingView)
+            companionWindow.orderFrontRegardless()
+
+            companionPresentations[displayID] = CompanionTimelinePresentation(
+                runtimeDisplayID: displayID,
+                stableDisplayID: identity.stableID,
+                displayName: identity.name,
+                window: companionWindow,
+                hostingView: hostingView,
+                viewModel: companionViewModel
+            )
+
+            Log.info(
+                "[TIMELINE-MULTI-DISPLAY] Companion timeline shown displayName=\(identity.name ?? "nil") runtimeID=\(displayID) stableID=\(identity.stableID)",
+                category: .ui
+            )
+
+            Task { @MainActor [weak self, weak companionViewModel, weak primaryViewModel] in
+                guard let self, let companionViewModel else { return }
+                await companionViewModel.loadMostRecentFrame()
+                guard !Task.isCancelled,
+                      self.companionPresentations[displayID]?.viewModel === companionViewModel,
+                      let timestamp = primaryViewModel?.currentTimestamp else {
+                    return
+                }
+                await companionViewModel.synchronizeToTimestamp(timestamp)
+            }
+        }
+
+        startCompanionTimelineSync(primaryViewModel: primaryViewModel)
+    }
+
+    private func startCompanionTimelineSync(primaryViewModel: SimpleTimelineViewModel) {
+        companionSyncCancellable?.cancel()
+        companionSyncCancellable = primaryViewModel.$currentIndex
+            .removeDuplicates()
+            .debounce(for: .milliseconds(80), scheduler: RunLoop.main)
+            .sink { [weak self, weak primaryViewModel] _ in
+                Task { @MainActor [weak self, weak primaryViewModel] in
+                    guard let self,
+                          let timestamp = primaryViewModel?.currentTimestamp else {
+                        return
+                    }
+                    self.syncCompanionTimelines(to: timestamp)
+                }
+            }
+
+        if let timestamp = primaryViewModel.currentTimestamp {
+            syncCompanionTimelines(to: timestamp)
+        }
+    }
+
+    private func syncCompanionTimelines(to timestamp: Date) {
+        companionSyncTask?.cancel()
+        let presentations = Array(companionPresentations.values)
+        companionSyncTask = Task { @MainActor in
+            for presentation in presentations {
+                guard !Task.isCancelled else { return }
+                await presentation.viewModel.synchronizeToTimestamp(timestamp)
+            }
+        }
+    }
+
+    private func closeCompanionTimelines() {
+        companionSyncCancellable?.cancel()
+        companionSyncCancellable = nil
+        companionSyncTask?.cancel()
+        companionSyncTask = nil
+
+        for presentation in companionPresentations.values {
+            presentation.viewModel.setPresentationWorkEnabled(false, reason: "timeline companion close")
+            presentation.window.orderOut(nil)
+            presentation.hostingView.removeFromSuperview()
+            presentation.window.close()
+        }
+        companionPresentations.removeAll(keepingCapacity: false)
     }
 
     private func destroyMountedPresentation() {
@@ -1992,6 +2191,7 @@ public class TimelineWindowController: NSObject {
         cancelWindowFadeIn(reason: "destroyMountedPresentation")
         cancelDeferredSearchOverlayRestore()
         cancelDeferredLiveActivation()
+        closeCompanionTimelines()
         liveModeCaptureTask?.cancel()
         liveModeCaptureTask = nil
         stopObservingApplicationActivation()
@@ -2443,6 +2643,7 @@ public class TimelineWindowController: NSObject {
         }
 
         let viewModel = ensurePreparedViewModel(coordinator: coordinator)
+        applyPrimaryDisplayScope(on: targetScreen, to: viewModel)
 
         mountPresentationIfNeeded(
             on: targetScreen,
@@ -2497,6 +2698,12 @@ public class TimelineWindowController: NSObject {
             DispatchQueue.main.async { [weak hostingView] in
                 hostingView?.layoutSubtreeIfNeeded()
             }
+        }
+        if let primaryViewModel = timelineViewModel {
+            showCompanionTimelinesIfNeeded(
+                coordinator: coordinator,
+                primaryViewModel: primaryViewModel
+            )
         }
 
         if let viewModel = timelineViewModel {


### PR DESCRIPTION
## Summary
- record frames from all connected displays with persisted stable display identity
- store/query display metadata on frames and video segments
- scope timeline playback by display and add synced companion windows for connected monitors

## Verification
- swift build
- swift test --filter RetraceTests.TimelineBlockNavigationTests
- git diff --check
- xcodebuild -project Retrace.xcodeproj -scheme Retrace -configuration Debug build CODE_SIGNING_ALLOWED=NO -derivedDataPath /tmp/retrace-xcodebuild-dd