### PR TITLE
fix(db): redact SQLCipher key/password from execSQL error text

### DIFF
--- a/Database/ReadConnectionSupport.swift
+++ b/Database/ReadConnectionSupport.swift
@@ -196,8 +196,21 @@ public enum SQLiteReadOnlyConnectionFactory {
 
         guard sqlite3_exec(db, sql, nil, nil, &errorMessage) == SQLITE_OK else {
             let message = errorMessage.map { String(cString: $0) } ?? String(cString: sqlite3_errmsg(db))
-            throw DatabaseConnectionError.executionFailed(sql: sql, error: message)
+            // Never surface the raw SQL for keying statements: PRAGMA key / rekey
+            // embed the SQLCipher key hex (or the Rewind password), and callers log
+            // executionFailed to the plaintext log file / feedback uploads.
+            throw DatabaseConnectionError.executionFailed(sql: redactedSQL(sql), error: message)
         }
+    }
+
+    /// Redacts secret material from a SQL string before it is placed in a thrown/logged
+    /// error. `PRAGMA key` / `PRAGMA rekey` carry the database key or password.
+    private static func redactedSQL(_ sql: String) -> String {
+        let lowered = sql.lowercased()
+        if lowered.contains("pragma key") || lowered.contains("pragma rekey") {
+            return "PRAGMA key = <redacted>;"
+        }
+        return sql
     }
 }
 


### PR DESCRIPTION
## Problem
`execSQL` threw `DatabaseConnectionError.executionFailed(sql:error:)` with the **raw SQL**, and the two `PRAGMA key` call sites pass `PRAGMA key = "x'<hex>'"` (Retrace DB key) and `PRAGMA key = '<password>'` (Rewind import password). Callers log these errors to the plaintext log file that is also uploaded in feedback diagnostics — leaking the key/password.

## Fix
Redact `PRAGMA key`/`rekey` statements to `PRAGMA key = <redacted>;` before they enter the thrown error.

Security review finding **#23**. (Part of the broader logging-privacy issue tracked separately.)

---
⚠️ Authored from a whole-repo security review (see the tracking issue). **Not yet build-verified in CI** — please run the app/test build before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
