### PR TITLE
fix(capture): redaction masking must fail closed, not persist the unmasked frame

### DIFF
--- a/Capture/ScreenCapture/CGWindowListCapture.swift
+++ b/Capture/ScreenCapture/CGWindowListCapture.swift
@@ -1195,8 +1195,11 @@ public actor CGWindowListCapture {
                 space: colorSpace,
                 bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
               ) else {
-            Log.error("[Masking] Failed to create graphics context", category: .capture)
-            return FilteredCaptureResult(image: fullScreenImage, visibleExcludedWindowIDs: [])
+            Log.error("[Masking] Failed to create graphics context - dropping frame to avoid leaking excluded windows", category: .capture)
+            // Fail closed: excluded/private windows are visible and we could not mask
+            // them. Returning the unmasked capture would persist a full screenshot of
+            // exactly the content the user marked as sensitive. Drop the frame instead.
+            return nil
         }
 
         // Draw the full screen image
@@ -1204,8 +1207,9 @@ public actor CGWindowListCapture {
 
         let fullImageRect = CGRect(x: 0, y: 0, width: width, height: height)
         guard let blurredImage = makeBlurredRedactionImage(from: fullScreenImage) else {
-            Log.error("[Masking] Failed to create blurred redaction image", category: .capture)
-            return FilteredCaptureResult(image: fullScreenImage, visibleExcludedWindowIDs: [])
+            Log.error("[Masking] Failed to create blurred redaction image - dropping frame to avoid leaking excluded windows", category: .capture)
+            // Fail closed (see above): drop rather than persist an unmasked capture.
+            return nil
         }
 
         var maskPaths: [CGPath] = []
@@ -1255,8 +1259,9 @@ public actor CGWindowListCapture {
         context.restoreGState()
 
         guard let maskedImage = context.makeImage() else {
-            Log.error("[Masking] Failed to create masked image", category: .capture)
-            return FilteredCaptureResult(image: fullScreenImage, visibleExcludedWindowIDs: [])
+            Log.error("[Masking] Failed to create masked image - dropping frame to avoid leaking excluded windows", category: .capture)
+            // Fail closed (see above): drop rather than persist an unmasked capture.
+            return nil
         }
 
         let visibleExcludedWindowIDs = Set(visibleExcludedRegions.map { $0.windowID })


### PR DESCRIPTION
## Problem
`captureWithMasking()` captures the full screen, then blurs excluded regions. On **any** compositing failure (CGContext creation, blurred-image creation, or `context.makeImage()`) it returned the **original unmasked full-screen image** with an empty `visibleExcludedWindowIDs` set. That frame carries no redaction reason and is persisted + OCR'd as normal — so a transient CoreImage/CGContext failure under memory pressure **stored a full unredacted screenshot of an excluded app or private/incognito window**.

## Fix
Return `nil` on those three failure paths so the frame is **dropped (fail closed)**, matching how capture-block reasons and `CGDisplayCreateImage` failures already behave (`captureWithFiltering` returns `FilteredCaptureResult?`). The *"fully occluded"* and *"regions too small"* branches are legitimately nothing-to-mask and are unchanged.

Security review finding **#9** (Theme B).

---
⚠️ Authored from a whole-repo security review (see the tracking issue). **Not yet build-verified in CI** — please run the app/test build before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
