### PR TITLE
perf: encode JPEG via ImageIO CGImageDestination instead of TIFF round-trip

### DIFF
--- a/Storage/ImageExtractor.swift
+++ b/Storage/ImageExtractor.swift
@@ -1,6 +1,7 @@
 import Foundation
 import AppKit
 import AVFoundation
+import ImageIO
 import Shared
 
 /// Protocol for extracting frame images from video storage
@@ -476,16 +477,28 @@ public final class HEVCStorageExtractor: ImageExtractor, FrameExtractionCacheInv
     }
 
     private func convertToJPEG(cgImage: CGImage, path: String) throws -> Data {
-        let nsImage = NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
-        guard let tiffData = nsImage.tiffRepresentation,
-              let bitmapImage = NSBitmapImageRep(data: tiffData),
-              let jpegData = bitmapImage.representation(
-                using: .jpeg,
-                properties: [.compressionFactor: 0.8]
-              ) else {
+        // Encode straight from the CGImage via ImageIO. The previous
+        // NSImage -> tiffRepresentation -> NSBitmapImageRep path materialized a
+        // full uncompressed copy of the frame (~24MB at Retina) plus a re-decode
+        // on every extraction; this is on the timeline scrubbing hot path.
+        let data = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(
+            data as CFMutableData,
+            "public.jpeg" as CFString,
+            1,
+            nil
+        ) else {
             throw ImageExtractionError.conversionFailed(path: path)
         }
-        return jpegData
+        CGImageDestinationAddImage(
+            destination,
+            cgImage,
+            [kCGImageDestinationLossyCompressionQuality: 0.8] as CFDictionary
+        )
+        guard CGImageDestinationFinalize(destination) else {
+            throw ImageExtractionError.conversionFailed(path: path)
+        }
+        return data as Data
     }
 
     public func purgeFrameExtractionCaches(reason: String) {
@@ -692,16 +705,28 @@ public final class AVAssetExtractor: ImageExtractor, FrameExtractionCacheInvalid
     }
 
     private func convertToJPEG(cgImage: CGImage, path: String) throws -> Data {
-        let nsImage = NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
-        guard let tiffData = nsImage.tiffRepresentation,
-              let bitmapImage = NSBitmapImageRep(data: tiffData),
-              let jpegData = bitmapImage.representation(
-                using: .jpeg,
-                properties: [.compressionFactor: 0.8]
-              ) else {
+        // Encode straight from the CGImage via ImageIO. The previous
+        // NSImage -> tiffRepresentation -> NSBitmapImageRep path materialized a
+        // full uncompressed copy of the frame (~24MB at Retina) plus a re-decode
+        // on every extraction; this is on the timeline scrubbing hot path.
+        let data = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(
+            data as CFMutableData,
+            "public.jpeg" as CFString,
+            1,
+            nil
+        ) else {
             throw ImageExtractionError.conversionFailed(path: path)
         }
-        return jpegData
+        CGImageDestinationAddImage(
+            destination,
+            cgImage,
+            [kCGImageDestinationLossyCompressionQuality: 0.8] as CFDictionary
+        )
+        guard CGImageDestinationFinalize(destination) else {
+            throw ImageExtractionError.conversionFailed(path: path)
+        }
+        return data as Data
     }
 
     public func purgeFrameExtractionCaches(reason: String) {

--- a/Storage/StorageManager.swift
+++ b/Storage/StorageManager.swift
@@ -2,6 +2,7 @@ import AppKit
 import AVFoundation
 import Darwin
 import Foundation
+import ImageIO
 import Shared
 import CoreMedia
 
@@ -1227,13 +1228,28 @@ public actor StorageManager: StorageProtocol {
             )
         }
 
-        let nsImage = NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
-        guard let tiffData = nsImage.tiffRepresentation,
-              let bitmap = NSBitmapImageRep(data: tiffData),
-              let jpegData = bitmap.representation(using: .jpeg, properties: [.compressionFactor: 0.8]) else {
+        // Encode straight from the CGImage via ImageIO, avoiding the
+        // NSImage -> tiffRepresentation -> NSBitmapImageRep round-trip (a full
+        // uncompressed frame copy + re-decode). The transient-bytes ledger
+        // accounting above is kept so memory telemetry stays consistent.
+        let data = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(
+            data as CFMutableData,
+            "public.jpeg" as CFString,
+            1,
+            nil
+        ) else {
             throw StorageError.fileReadFailed(path: "", underlying: "Failed to convert CGImage to JPEG")
         }
-        return jpegData
+        CGImageDestinationAddImage(
+            destination,
+            cgImage,
+            [kCGImageDestinationLossyCompressionQuality: 0.8] as CFDictionary
+        )
+        guard CGImageDestinationFinalize(destination) else {
+            throw StorageError.fileReadFailed(path: "", underlying: "Failed to convert CGImage to JPEG")
+        }
+        return data as Data
     }
 
     static func makeBGRAData(from image: CGImage) throws -> Data {


### PR DESCRIPTION
## Problem
`convertToJPEG` / `convertCGImageToJPEG` encode via `CGImage → NSImage → tiffRepresentation → NSBitmapImageRep → JPEG`. The `tiffRepresentation` step materializes a **full uncompressed copy** of the frame (~24 MB for a 3024×1964 Retina frame, more at 5K) and `NSBitmapImageRep` **re-decodes** it — two extra full-frame buffers + a TIFF encode **per extraction**, on the timeline-scrubbing hot path.

Three identical sites: `ImageExtractor.swift:478` & `:694`, `StorageManager.swift:1216` (called from the decode/scrub paths).

## Fix
Encode directly from the `CGImage` with `CGImageDestination` (`kCGImageDestinationLossyCompressionQuality: 0.8`, matching the prior `0.8` compressionFactor). Output bytes aren't bit-identical, but callers consume opaque JPEG `Data`. `StorageManager` keeps its transient-bytes ledger wrapper so memory telemetry is unchanged. Adds `import ImageIO`.

Perf/disk review candidate #1 (CONFIRMED, low-risk).

---
Found via a Fable 5 perf/disk sweep (see the perf/disk tracking issue). **Not build-verified in CI.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
