### PR TITLE
fix: preserve IME composition in spotlight search fields

### DIFF
--- a/UI/Views/FullscreenTimeline/SpotlightSearchOverlay.swift
+++ b/UI/Views/FullscreenTimeline/SpotlightSearchOverlay.swift
@@ -2140,7 +2140,9 @@ struct SpotlightSearchField: NSViewRepresentable {
     }
 
     func updateNSView(_ textField: FocusableTextField, context: Context) {
-        if textField.stringValue != text {
+        // Skip the write-back while IME composition is active; it would commit marked text.
+        let isComposing = (textField.currentEditor() as? NSTextView)?.hasMarkedText() ?? false
+        if !isComposing, textField.stringValue != text {
             textField.stringValue = text
         }
         // Update the click callback in case onFocus changed


### PR DESCRIPTION
## Summary

Fixes a bug where IME composition in the Spotlight search field was committed on every keystroke, making Japanese/CJK conversion unusable.

`SpotlightSearchField.updateNSView` wrote `textField.stringValue` unconditionally. During composition, `controlTextDidChange` updates the `text` binding with the in-progress reading, which re-triggers `updateNSView`. Writing `stringValue` there commits the marked text and ends composition, so each keystroke is confirmed prematurely. This affects all composition-based input methods (Japanese, Chinese, Korean, etc.), not just multibyte confirmation.

## Changes

- Guard the `stringValue` write-back in `SpotlightSearchField.updateNSView` while the field editor `hasMarkedText()`:

```swift
let isComposing = (textField.currentEditor() as? NSTextView)?.hasMarkedText() ?? false
if !isComposing, textField.stringValue != text {
    textField.stringValue = text
}
```

## Testing

- [ ] Unit tests added/updated
- [x] Integration tests pass
- [x] Manual testing performed

`swift test` passes locally.

IME composition depends on the live `NSTextInputClient` field editor and an active input source, so it is not meaningfully unit-testable; the fix itself was verified manually. With a Japanese input source, marked text is now preserved during composition and confirms normally, instead of being committed on every keystroke.

## Screenshots (if UI changes)

**Before**

https://github.com/user-attachments/assets/2b153c55-941a-47e2-a983-e43ed57bf57e

**After**

https://github.com/user-attachments/assets/daad9b5e-c365-46cd-85a4-03c9c236489f

## Related Issues

_None._

## Checklist

- [x] Tests pass locally
- [ ] Documentation updated
- [x] No new warnings
- [x] Follows coding standards

🤖 Generated with [Claude Code](https://claude.com/claude-code)