### PR TITLE
build: declare the test-target dependencies that cold builds actually need

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -74,7 +74,10 @@ let package = Package(
         ),
         .testTarget(
             name: "DatabaseTests",
-            dependencies: ["Database", "Shared"],
+            // Storage/Processing/Search are imported by AsyncQueuePipelineTests. Undeclared,
+            // a cold build races and fails with "no such module 'Processing'" -- it only ever
+            // worked because another target happened to build them first.
+            dependencies: ["Database", "Shared", "Storage", "Processing", "Search"],
             path: "Database/Tests",
             exclude: [
                 "_future"  // Release 2+ tests
@@ -209,7 +212,8 @@ let package = Package(
             dependencies: [
                 "App",
                 "Database",
-                "Shared"
+                "Shared",
+                "Storage"
             ],
             path: "App/Tests"
             // ⚠️ RELEASE 2 ONLY - Whisper cSettings and linkerSettings removed for Release 1
@@ -284,7 +288,7 @@ let package = Package(
         ),
         .testTarget(
             name: "RetraceTests",
-            dependencies: ["Retrace", "CrashRecoverySupport", "Shared", "App"],
+            dependencies: ["Retrace", "CrashRecoverySupport", "Shared", "App", "Processing"],
             path: "UI/Tests"
             // ⚠️ RELEASE 2 ONLY - Whisper cSettings and linkerSettings removed for Release 1
         ),


### PR DESCRIPTION
A clean clone cannot build the test targets.

```
$ git clone … && cd retrace
$ swift build --build-tests
Database/Tests/AsyncQueuePipelineTests.swift:10:18: error: no such module 'Processing'
… 18 errors
exit 1
```

Three test targets import modules they never declare in `Package.swift`. It only shows up on a **cold** build — once `.build` is populated the import resolves from artifacts that another target happened to produce, so it is invisible to anyone with a warm checkout, which is presumably why it has survived.

Verified on a fresh worktree at `main` (`621d762`): 18 `no such module` errors before, `Build complete!` after.

This blocks `swift test` entirely from a clean checkout, so it is worth landing before the other PRs I am opening.