### PR TITLE
test(rewrite): make the rewrite tests hermetic so the suite can finish

### DIFF
--- a/Processing/FrameProcessingQueue.swift
+++ b/Processing/FrameProcessingQueue.swift
@@ -491,6 +491,14 @@ public actor FrameProcessingQueue {
     private let processing: ProcessingProtocol
     private let search: SearchProtocol
 
+    /// Supplies the app-wide OCR scrambling secret.
+    ///
+    /// Defaults to the Keychain-backed master key. It is injectable because reading the
+    /// Keychain makes rewrite behaviour depend on ambient machine state: on a host with no
+    /// master key every redaction rewrite silently defers with `.missingMasterKey`, which is
+    /// correct for the app but makes the rewrite tests unrunnable.
+    private let appWideSecretProvider: @Sendable () -> String?
+
     private let config: ProcessingQueueConfig
     private var workers: [Task<Void, Never>] = []
     private var isRunning = false
@@ -570,13 +578,17 @@ public actor FrameProcessingQueue {
         storage: StorageProtocol,
         processing: ProcessingProtocol,
         search: SearchProtocol,
-        config: ProcessingQueueConfig = .default
+        config: ProcessingQueueConfig = .default,
+        appWideSecretProvider: @escaping @Sendable () -> String? = {
+            ReversibleOCRScrambler.currentAppWideSecret()
+        }
     ) {
         self.databaseManager = database
         self.storage = storage
         self.processing = processing
         self.search = search
         self.config = config
+        self.appWideSecretProvider = appWideSecretProvider
     }
 
     // MARK: - Power Configuration
@@ -2283,7 +2295,7 @@ public actor FrameProcessingQueue {
             return preliminaryResult
         }
 
-        let secret = ReversibleOCRScrambler.currentAppWideSecret()
+        let secret = appWideSecretProvider()
         let effectiveFrameID = actualFrameID ?? extracted.frameID.value
         let finalResult = Self.finalizedPhraseLevelRedactionResult(
             extracted: extracted,
@@ -2770,7 +2782,7 @@ public actor FrameProcessingQueue {
         }
 
         let actualSegmentID = try parseActualSegmentID(from: videoSegment.relativePath)
-        let secret = ReversibleOCRScrambler.currentAppWideSecret()
+        let secret = appWideSecretProvider()
         let executablePlan: VideoRewritePlan
 
         if plan.hasRedactionTargets && secret == nil {

--- a/Processing/Tests/RewriteRetryPolicyTests.swift
+++ b/Processing/Tests/RewriteRetryPolicyTests.swift
@@ -192,6 +192,32 @@ private struct RewriteTestTimeout: Error {
     let stage: String
 }
 
+/// Delivers whichever of two racing tasks finishes first and ignores the loser.
+private actor FirstRewriteTestOutcome<T: Sendable> {
+    private var resolved: Result<T, Error>?
+    private var waiter: CheckedContinuation<Result<T, Error>, Never>?
+
+    func resolve(_ outcome: Result<T, Error>) {
+        guard resolved == nil else { return }
+        resolved = outcome
+
+        if let waiter {
+            self.waiter = nil
+            waiter.resume(returning: outcome)
+        }
+    }
+
+    func firstOutcome() async -> Result<T, Error> {
+        if let resolved {
+            return resolved
+        }
+
+        return await withCheckedContinuation { continuation in
+            waiter = continuation
+        }
+    }
+}
+
 private actor BlockingRewriteStorage: StorageProtocol, RewriteAttemptCountingStorage {
     private var rewriteAttemptCount = 0
     private var firstRewriteStarted = false
@@ -466,6 +492,14 @@ final class RewriteRetryPolicyTests: XCTestCase {
     /// the entire run with it — one stuck test made the full suite unrunnable rather
     /// than merely red. This converts that into a named failure at the exact stage
     /// that stalled.
+    ///
+    /// The operation runs as an unstructured task deliberately. A task group cannot return
+    /// until every child has finished, and `cancelAll()` does nothing to a child parked in a
+    /// non-cancellable `withCheckedContinuation` — which is exactly what the waits here do.
+    /// A group-based timeout therefore reported the failure and *then* wedged the process
+    /// during teardown, leaving the run unable to finish even though it knew the answer.
+    /// Abandoning an unstructured task leaks a suspended task instead, which costs a little
+    /// memory and lets the suite report and move on.
     private func withTestTimeout<T: Sendable>(
         _ stage: String,
         seconds: Double = 20,
@@ -473,22 +507,36 @@ final class RewriteRetryPolicyTests: XCTestCase {
         line: UInt = #line,
         _ operation: @escaping @Sendable () async throws -> T
     ) async throws -> T {
-        try await withThrowingTaskGroup(of: T?.self) { group in
-            group.addTask { try await operation() }
-            group.addTask {
-                try? await Task.sleep(for: .seconds(seconds), clock: .continuous)
-                return nil
-            }
+        let outcome = FirstRewriteTestOutcome<T>()
 
-            defer { group.cancelAll() }
-            while let result = try await group.next() {
-                if let result {
-                    return result
-                }
-                XCTFail("Timed out after \(seconds)s waiting for: \(stage)", file: file, line: line)
-                throw RewriteTestTimeout(stage: stage)
+        let operationTask = Task {
+            do {
+                await outcome.resolve(.success(try await operation()))
+            } catch {
+                await outcome.resolve(.failure(error))
             }
-            throw RewriteTestTimeout(stage: stage)
+        }
+        let timeoutTask = Task {
+            try? await Task.sleep(for: .seconds(seconds), clock: .continuous)
+            await outcome.resolve(.failure(RewriteTestTimeout(stage: stage)))
+        }
+        defer {
+            operationTask.cancel()
+            timeoutTask.cancel()
+        }
+
+        switch await outcome.firstOutcome() {
+        case .success(let value):
+            return value
+        case .failure(let error):
+            if let timeout = error as? RewriteTestTimeout {
+                XCTFail(
+                    "Timed out after \(seconds)s waiting for: \(timeout.stage)",
+                    file: file,
+                    line: line
+                )
+            }
+            throw error
         }
     }
 

--- a/Processing/Tests/RewriteRetryPolicyTests.swift
+++ b/Processing/Tests/RewriteRetryPolicyTests.swift
@@ -300,6 +300,13 @@ private actor BlockingRewriteStorage: StorageProtocol, RewriteAttemptCountingSto
 }
 
 final class RewriteRetryPolicyTests: XCTestCase {
+    /// The secret the fixtures encrypt node text with.
+    ///
+    /// It is injected into the queue rather than read from the Keychain: `processPendingRewrites`
+    /// defers with `.missingMasterKey` when no app-wide secret exists, so reading real machine
+    /// state would make every rewrite here depend on whether the host happens to have run the app.
+    private static let testAppWideSecret = "test-secret"
+
     private var database: DatabaseManager!
     private var queue: FrameProcessingQueue!
     private var storage: FailingRewriteStorage!
@@ -320,7 +327,8 @@ final class RewriteRetryPolicyTests: XCTestCase {
                 maxRetryAttempts: 3,
                 maxQueueSize: 1000,
                 retryableRewriteRetryDelayNs: 50_000_000
-            )
+            ),
+            appWideSecretProvider: { Self.testAppWideSecret }
         )
     }
 
@@ -379,7 +387,8 @@ final class RewriteRetryPolicyTests: XCTestCase {
                 maxRetryAttempts: 3,
                 maxQueueSize: 1000,
                 retryableRewriteRetryDelayNs: 50_000_000
-            )
+            ),
+            appWideSecretProvider: { Self.testAppWideSecret }
         )
 
         let fixture = try await insertVideoFixture(frameCount: 2)
@@ -623,7 +632,7 @@ final class RewriteRetryPolicyTests: XCTestCase {
             text,
             frameID: frameID.value,
             nodeOrder: 0,
-            secret: "test-secret"
+            secret: Self.testAppWideSecret
         ) ?? text
         try await database.insertNodes(
             frameID: frameID,

--- a/Processing/Tests/RewriteRetryPolicyTests.swift
+++ b/Processing/Tests/RewriteRetryPolicyTests.swift
@@ -188,8 +188,13 @@ private actor FailingRewriteStorage: StorageProtocol, RewriteAttemptCountingStor
     }
 }
 
-private struct RewriteTestTimeout: Error {
+private struct RewriteTestTimeout: Error, CustomStringConvertible {
     let stage: String
+    let seconds: Double
+
+    var description: String {
+        "Timed out after \(seconds)s waiting for: \(stage)"
+    }
 }
 
 /// Delivers whichever of two racing tasks finishes first and ignores the loser.
@@ -518,7 +523,7 @@ final class RewriteRetryPolicyTests: XCTestCase {
         }
         let timeoutTask = Task {
             try? await Task.sleep(for: .seconds(seconds), clock: .continuous)
-            await outcome.resolve(.failure(RewriteTestTimeout(stage: stage)))
+            await outcome.resolve(.failure(RewriteTestTimeout(stage: stage, seconds: seconds)))
         }
         defer {
             operationTask.cancel()
@@ -529,13 +534,8 @@ final class RewriteRetryPolicyTests: XCTestCase {
         case .success(let value):
             return value
         case .failure(let error):
-            if let timeout = error as? RewriteTestTimeout {
-                XCTFail(
-                    "Timed out after \(seconds)s waiting for: \(timeout.stage)",
-                    file: file,
-                    line: line
-                )
-            }
+            // Throwing from an async test already records a failure carrying this
+            // error's description, so an XCTFail here would report the same timeout twice.
             throw error
         }
     }

--- a/Processing/Tests/RewriteRetryPolicyTests.swift
+++ b/Processing/Tests/RewriteRetryPolicyTests.swift
@@ -188,6 +188,10 @@ private actor FailingRewriteStorage: StorageProtocol, RewriteAttemptCountingStor
     }
 }
 
+private struct RewriteTestTimeout: Error {
+    let stage: String
+}
+
 private actor BlockingRewriteStorage: StorageProtocol, RewriteAttemptCountingStorage {
     private var rewriteAttemptCount = 0
     private var firstRewriteStarted = false
@@ -402,7 +406,9 @@ final class RewriteRetryPolicyTests: XCTestCase {
         let firstRewriteTask = Task {
             try await blockingQueue.processPendingRewrites(for: fixture.videoID.value)
         }
-        await blockingStorage.waitForFirstRewriteToStart()
+        try await withTestTimeout("first rewrite to start") {
+            await blockingStorage.waitForFirstRewriteToStart()
+        }
 
         let secondFrameID = try await insertFrameReference(
             segmentID: fixture.segmentID,
@@ -423,11 +429,17 @@ final class RewriteRetryPolicyTests: XCTestCase {
             rewritePurpose: "redaction"
         )
 
-        let deferredOutcome = try await blockingQueue.processPendingRewrites(for: fixture.videoID.value)
+        let deferredOutcome = try await withTestTimeout(
+            "second processPendingRewrites to return .deferred(.rewriteAlreadyInProgress)"
+        ) {
+            try await blockingQueue.processPendingRewrites(for: fixture.videoID.value)
+        }
         XCTAssertEqual(deferredOutcome, .deferred(.rewriteAlreadyInProgress))
 
         await blockingStorage.releaseFirstRewrite()
-        let firstRewriteOutcome = try await firstRewriteTask.value
+        let firstRewriteOutcome = try await withTestTimeout("first rewrite task to finish") {
+            try await firstRewriteTask.value
+        }
         XCTAssertEqual(firstRewriteOutcome, .completed)
 
         try await waitForRewriteAttemptCount(2, in: blockingStorage)
@@ -437,6 +449,38 @@ final class RewriteRetryPolicyTests: XCTestCase {
         )
         XCTAssertEqual(statuses[firstFrameID.value], FrameProcessingStatus.rewriteCompleted.rawValue)
         XCTAssertEqual(statuses[secondFrameID.value], FrameProcessingStatus.rewriteCompleted.rawValue)
+    }
+
+    /// Bounds an await that would otherwise hang the whole test process.
+    ///
+    /// `swift test` has no per-test timeout, so a suspension that never resumes takes
+    /// the entire run with it — one stuck test made the full suite unrunnable rather
+    /// than merely red. This converts that into a named failure at the exact stage
+    /// that stalled.
+    private func withTestTimeout<T: Sendable>(
+        _ stage: String,
+        seconds: Double = 20,
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        _ operation: @escaping @Sendable () async throws -> T
+    ) async throws -> T {
+        try await withThrowingTaskGroup(of: T?.self) { group in
+            group.addTask { try await operation() }
+            group.addTask {
+                try? await Task.sleep(for: .seconds(seconds), clock: .continuous)
+                return nil
+            }
+
+            defer { group.cancelAll() }
+            while let result = try await group.next() {
+                if let result {
+                    return result
+                }
+                XCTFail("Timed out after \(seconds)s waiting for: \(stage)", file: file, line: line)
+                throw RewriteTestTimeout(stage: stage)
+            }
+            throw RewriteTestTimeout(stage: stage)
+        }
     }
 
     private func waitForRewriteAttemptCount<Storage: RewriteAttemptCountingStorage>(


### PR DESCRIPTION
An unfiltered `swift test` never completes on `main`. It wedges in `RewriteRetryPolicyTests` and hangs forever — no failure, no timeout, just a run that never returns.

## Cause

`FrameProcessingQueue` reads the app-wide OCR secret from the login Keychain. The test asserted on a rewrite path that only proceeds when that secret exists, so the outcome depended on ambient machine state: it passed on machines that had run the app and hung on machines that had not. CI, or any fresh clone, is the second kind.

The rewrite itself is correct to defer — the production guard refuses to rewrite redactions without a master key and resets the plan to pending. The defect was entirely in the test.

## Fix

- Inject the secret through an `appWideSecretProvider` that still defaults to `ReversibleOCRScrambler.currentAppWideSecret()`, so **production behaviour is unchanged**; the tests inject `"test-secret"`, which is what the fixtures already encrypt node text with.
- Replace the task-group timeout helper with an unstructured-task race resolved through an actor, so a stalled wait **fails the test** instead of wedging the process.
- Bound the deferred-rewrite waits so a stall is diagnosable rather than infinite.

## Verified

On `main` + #42 (needed for the test targets to build at all):

```
before   swift test --filter RewriteRetryPolicyTests   still running after 150s, killed
after    swift test --filter RewriteRetryPolicyTests   Executed 2 tests, 0 failures, 0.366s
```

Depends on #42.