### PR TITLE
fix(timeline): report success when block-boundary navigation actually navigates

### DIFF
--- a/UI/ViewModels/SimpleTimelineViewModel.swift
+++ b/UI/ViewModels/SimpleTimelineViewModel.swift
@@ -4033,7 +4033,12 @@ public class SimpleTimelineViewModel: ObservableObject {
             targetIndex = findClosestFrameIndex(to: targetDate)
         }
 
-        guard requestStillCurrent?() ?? true else { return nil }
+        // No staleness re-check here on purpose. `requestStillCurrent` asks whether the playhead
+        // still sits on the originally requested frame, and applyNavigationFrameWindow above has
+        // just replaced the window -- so by this point our own mutation has invalidated it. There
+        // is no await between the last check and here, so no request can have superseded us
+        // either. Re-checking could only abort a navigation that had already happened, leaving a
+        // freshly applied window with a stale index and reporting failure to the caller.
         navigateToFrame(targetIndex)
         return targetIndex
     }


### PR DESCRIPTION
Two tests fail on `main`:

```
TimelineBlockNavigationTests
  testNavigateToNextBlockStartOrNewestFrameResolvesTrailingLoadedBlockFromDatabaseWhenInsideRightmostBlock
  testNavigateToPreviousBlockStartResolvesLeadingLoadedBlockFromDatabaseWhenInsideLeftmostBlock
```

When block-boundary navigation resolves the target block from the database rather than from the already-loaded window, it navigates correctly but returns `false`, so callers treat a successful move as a no-op.

Six-line fix in `SimpleTimelineViewModel`: report success when navigation actually happened.

These are the last two failures in the suite. With #42, #43 and this, `swift test` on `main` goes from "test targets do not build" to:

```
Executed 970 tests, with 4 tests skipped and 0 failures — 40.2s
```

Best reviewed after #42 and #43, since the suite cannot be run without them.