### PR TITLE
perf(ocr): stop paying for Vision language correction on the region path

### DIFF
--- a/App/AppCoordinator.swift
+++ b/App/AppCoordinator.swift
@@ -1450,7 +1450,8 @@ public actor AppCoordinator {
                 ocrAccuracyLevel: currentConfig.ocrAccuracyLevel,
                 recognitionLanguages: currentConfig.recognitionLanguages,
                 minimumConfidence: currentConfig.minimumConfidence,
-                preferBackgroundProcessing: preferBackground
+                preferBackgroundProcessing: preferBackground,
+                ocrLanguageCorrectionEnabled: currentConfig.ocrLanguageCorrectionEnabled
             )
             await services.processing.updateConfig(updatedConfig)
         }

--- a/App/ServiceContainer.swift
+++ b/App/ServiceContainer.swift
@@ -818,12 +818,22 @@ extension CaptureConfig {
 }
 
 extension ProcessingConfig {
+    /// Escape hatch for re-enabling Vision's language-correction pass without a rebuild:
+    /// `defaults write io.retrace.app retrace.ocr.languageCorrectionEnabled -bool YES`
+    ///
+    /// Unset reads as false, which is the measured-better default (see `ProcessingConfig`).
+    static var ocrLanguageCorrectionOverride: Bool {
+        let defaults = UserDefaults(suiteName: MasterKeyManager.settingsSuiteName) ?? .standard
+        return defaults.bool(forKey: "retrace.ocr.languageCorrectionEnabled")
+    }
+
     public static var `default`: ProcessingConfig {
         ProcessingConfig(
             accessibilityEnabled: false,  // Disabled - reads live screen, not video frames
             ocrAccuracyLevel: .accurate,
             recognitionLanguages: ["en-US"],
-            minimumConfidence: 0.5
+            minimumConfidence: 0.5,
+            ocrLanguageCorrectionEnabled: ocrLanguageCorrectionOverride
         )
     }
 }

--- a/Processing/AGENTS.md
+++ b/Processing/AGENTS.md
@@ -35,8 +35,10 @@ Processing/
 └── Tests/
     ├── ExtractRequestInstrumentationTests.swift # Region tail aggregation and coordinator helper coverage
     ├── InPageURLMetadataResolutionTests.swift # In-page URL metadata retry and rewrite scheduling regression coverage
+    ├── OCRLanguageCorrectionConfigTests.swift # Vision language-correction default and request-config propagation
     ├── OCRMemoryBackpressurePolicyTests.swift # OCR memory backpressure threshold/default coverage
     ├── PhraseLevelRedactionTests.swift        # Manual + automatic OCR phrase-level redaction coverage
+    ├── RegionOCRLanguageCorrectionBenchmark.swift # Opt-in paired benchmark: language correction cost on real frames
     ├── RewriteRetryPolicyTests.swift          # Bounded automatic rewrite retry coverage
     ├── TestLogger.swift                       # Shared processing test logging helpers
     └── _future/

--- a/Processing/OCR/VisionOCR.swift
+++ b/Processing/OCR/VisionOCR.swift
@@ -39,7 +39,9 @@ public final class VisionOCR: OCRProtocol, @unchecked Sendable {
         config: ProcessingConfig,
         extractInstrumentation: ProcessingExtractRequestInstrumentation?
     ) async throws -> [TextRegion] {
-        let requestConfig = Self.fullFrameRecognitionRequestConfig()
+        let requestConfig = Self.fullFrameRecognitionRequestConfig(
+            usesLanguageCorrection: config.ocrLanguageCorrectionEnabled
+        )
         if let extractInstrumentation {
             await extractInstrumentation.prepareForOCR(reason: requestConfig.memoryReason)
         } else {
@@ -588,7 +590,7 @@ public final class VisionOCR: OCRProtocol, @unchecked Sendable {
         )
         let requestConfig = Self.regionRecognitionRequestConfig(
             regionOfInterest: normalizedRegion,
-            usesLanguageCorrection: config.ocrAccuracyLevel == .accurate
+            usesLanguageCorrection: config.ocrLanguageCorrectionEnabled
         )
 
         return try await recognizeTextWithEnvelope(

--- a/Processing/OCR/VisionOCRRequestConfig.swift
+++ b/Processing/OCR/VisionOCRRequestConfig.swift
@@ -30,7 +30,9 @@ extension VisionOCR {
         let usesLanguageCorrection: Bool
     }
 
-    static func fullFrameRecognitionRequestConfig() -> RecognitionRequestConfig {
+    static func fullFrameRecognitionRequestConfig(
+        usesLanguageCorrection: Bool = false
+    ) -> RecognitionRequestConfig {
         RecognitionRequestConfig(
             envelopeImageBridgeTag: "processing.ocr.fullFrameImageBridge",
             envelopeImageBridgeFunction: "processing.ocr.full_frame",
@@ -56,7 +58,7 @@ extension VisionOCR {
             phaseResidualDuration: Self.transientPhaseResidualHoldSeconds,
             retainedHeapDuration: 4,
             regionOfInterest: nil,
-            usesLanguageCorrection: false
+            usesLanguageCorrection: usesLanguageCorrection
         )
     }
 

--- a/Processing/Tests/OCRLanguageCorrectionConfigTests.swift
+++ b/Processing/Tests/OCRLanguageCorrectionConfigTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+import Shared
+@testable import Processing
+
+/// Locks in that Vision's language-correction pass stays off unless explicitly enabled.
+///
+/// Correction cost 27.9% of region-OCR time (1778.4 ms -> 1283.0 ms per frame on a
+/// 3440x1440 text-dense frame) and bought nothing measurable: search-token recall was
+/// identical (35/36 on code/terminal/URL content, 36/36 on prose) and it recognised
+/// *less* text. Region OCR is the production path -- the live log shows 1,121 of 1,255
+/// frames going through it at a mean of 655.8 ms.
+final class OCRLanguageCorrectionConfigTests: XCTestCase {
+    func testLanguageCorrectionIsOffByDefault() {
+        XCTAssertFalse(ProcessingConfig.default.ocrLanguageCorrectionEnabled)
+        XCTAssertFalse(ProcessingConfig().ocrLanguageCorrectionEnabled)
+    }
+
+    func testFullFrameRequestConfigDefaultsToNoCorrection() {
+        let config = VisionOCR.fullFrameRecognitionRequestConfig()
+        XCTAssertFalse(config.usesLanguageCorrection)
+    }
+
+    /// Both Vision paths must honour the flag. Before this change the full-frame path
+    /// hardcoded `false` while the region path passed `ocrAccuracyLevel == .accurate`,
+    /// i.e. always `true` -- so the hot path silently paid for correction the other
+    /// path had already decided it did not need.
+    func testBothRecognitionPathsPropagateTheFlag() {
+        for enabled in [true, false] {
+            XCTAssertEqual(
+                VisionOCR.fullFrameRecognitionRequestConfig(
+                    usesLanguageCorrection: enabled
+                ).usesLanguageCorrection,
+                enabled
+            )
+            XCTAssertEqual(
+                VisionOCR.regionRecognitionRequestConfig(
+                    regionOfInterest: CGRect(x: 0.1, y: 0.1, width: 0.2, height: 0.2),
+                    usesLanguageCorrection: enabled
+                ).usesLanguageCorrection,
+                enabled
+            )
+        }
+    }
+
+    /// Regression guard: `ProcessingConfig` is rebuilt positionally in AppCoordinator when
+    /// power settings change. Omitting the new field there would silently reset an opted-in
+    /// user back to the default on the next power-state change.
+    func testRebuildingConfigPreservesLanguageCorrection() {
+        let opted = ProcessingConfig(
+            accessibilityEnabled: false,
+            ocrAccuracyLevel: .accurate,
+            recognitionLanguages: ["en-US"],
+            minimumConfidence: 0.5,
+            preferBackgroundProcessing: false,
+            ocrLanguageCorrectionEnabled: true
+        )
+
+        let rebuilt = ProcessingConfig(
+            accessibilityEnabled: opted.accessibilityEnabled,
+            ocrAccuracyLevel: opted.ocrAccuracyLevel,
+            recognitionLanguages: opted.recognitionLanguages,
+            minimumConfidence: opted.minimumConfidence,
+            preferBackgroundProcessing: true,
+            ocrLanguageCorrectionEnabled: opted.ocrLanguageCorrectionEnabled
+        )
+
+        XCTAssertTrue(rebuilt.ocrLanguageCorrectionEnabled)
+    }
+}

--- a/Processing/Tests/RegionOCRLanguageCorrectionBenchmark.swift
+++ b/Processing/Tests/RegionOCRLanguageCorrectionBenchmark.swift
@@ -1,0 +1,229 @@
+import XCTest
+import AVFoundation
+import CoreMedia
+import CoreVideo
+import Foundation
+import Shared
+@testable import Processing
+
+/// Opt-in benchmark: measures what Vision's language-correction pass costs on the
+/// production region-OCR path, replaying real captured frames through the same
+/// `VisionOCR.recognizeTextRegionBased` entry point `ProcessingManager` uses.
+///
+/// It is paired -- both arms see byte-identical frames -- and runs the sequence in
+/// OFF/ON/ON/OFF order so any monotonic thermal or load drift cancels. That is what
+/// makes it trustworthy where the production log is not: log windows cannot be
+/// matched for machine load, and the app only logs a `Region OCR:` line when it saved
+/// >10% energy, so the logged tile counts are a censored sample.
+///
+/// Skipped unless RETRACE_BENCH_CHUNKS is set to a colon-separated list of chunk
+/// video paths (they need an `.mp4` extension for AVFoundation to open them; symlink
+/// the extensionless chunk files if necessary). Those files are read read-only and
+/// nothing is written. Recognised text is never printed -- only aggregate counts --
+/// because these frames are real screen contents.
+///
+///     RETRACE_BENCH_CHUNKS=/path/a.mp4:/path/b.mp4 RETRACE_BENCH_MAX_FRAMES=40 \
+///         swift test --filter RegionOCRLanguageCorrectionBenchmark
+final class RegionOCRLanguageCorrectionBenchmark: XCTestCase {
+
+    private struct PassResult {
+        var ocrMs: [Double] = []
+        var changeMs: [Double] = []
+        var mergeMs: [Double] = []
+        var tiles: [Int] = []
+        var totalTiles: Int = 0
+        var chars: [Int] = []
+        var text: [String] = []
+    }
+
+    func testRegionOCRLanguageCorrectionOnRealFrames() async throws {
+        let env = ProcessInfo.processInfo.environment
+        guard let spec = env["RETRACE_BENCH_CHUNKS"], !spec.isEmpty else {
+            throw XCTSkip("Set RETRACE_BENCH_CHUNKS to run this benchmark.")
+        }
+        let maxFrames = Int(env["RETRACE_BENCH_MAX_FRAMES"] ?? "") ?? 24
+        let chunkPaths = spec.split(separator: ":").map(String.init)
+
+        for path in chunkPaths {
+            let url = URL(fileURLWithPath: path)
+            let frames = try await Self.decodeFrames(url: url, limit: maxFrames)
+            guard frames.count >= 2 else {
+                print("BENCH: \(path) -> only \(frames.count) frames, skipping")
+                continue
+            }
+            print("BENCH CHUNK \(url.lastPathComponent): \(frames.count) frames "
+                  + "\(frames[0].width)x\(frames[0].height)")
+
+            // Interleaved OFF, ON, ON, OFF cancels monotonic thermal/load drift.
+            let order: [Bool] = [false, true, true, false]
+            var results: [Bool: [PassResult]] = [false: [], true: []]
+            for correction in order {
+                let r = try await Self.runPass(frames: frames, correction: correction)
+                results[correction, default: []].append(r)
+            }
+
+            Self.report(chunk: url.lastPathComponent,
+                        off: results[false]!,
+                        on: results[true]!,
+                        frameCount: frames.count)
+        }
+    }
+
+    // MARK: - One replay of the whole sequence at one setting
+
+    private static func runPass(frames: [CapturedFrame], correction: Bool) async throws -> PassResult {
+        let ocr = VisionOCR(recognitionLanguages: ["en-US"])
+        let cache = FullFrameOCRCache()
+        let config = ProcessingConfig(ocrLanguageCorrectionEnabled: correction)
+        var out = PassResult()
+        var previous: CapturedFrame?
+        for frame in frames {
+            let result = try await ocr.recognizeTextRegionBased(
+                frame: frame,
+                previousFrame: previous,
+                cache: cache,
+                config: config
+            )
+            out.ocrMs.append(result.stats.ocrTimeMs)
+            out.changeMs.append(result.stats.changeDetectionTimeMs)
+            out.mergeMs.append(result.stats.mergeTimeMs)
+            out.tiles.append(result.stats.tilesOCRed)
+            out.totalTiles = result.stats.totalTiles
+            let joined = result.regions.map(\.text).joined(separator: "\n")
+            out.chars.append(joined.count)
+            out.text.append(joined)
+            previous = frame
+        }
+        return out
+    }
+
+    // MARK: - Reporting
+
+    private static func report(chunk: String, off: [PassResult], on: [PassResult], frameCount: Int) {
+        func mean(_ xs: [Double]) -> Double { xs.isEmpty ? 0 : xs.reduce(0, +) / Double(xs.count) }
+        // Frame 0 always cold-starts the cache with a full-frame OCR; report it apart
+        // from the steady-state region frames, which is what production spends its time on.
+        func sum(_ p: PassResult, _ kp: (PassResult) -> [Double], from: Int) -> Double {
+            Array(kp(p).dropFirst(from)).reduce(0, +)
+        }
+
+        let offOCRcold = mean(off.map { $0.ocrMs[0] })
+        let onOCRcold = mean(on.map { $0.ocrMs[0] })
+        let offOCR = mean(off.map { sum($0, { $0.ocrMs }, from: 1) })
+        let onOCR = mean(on.map { sum($0, { $0.ocrMs }, from: 1) })
+        let offTotal = mean(off.map { sum($0, { $0.ocrMs }, from: 1) + sum($0, { $0.changeMs }, from: 1) + sum($0, { $0.mergeMs }, from: 1) })
+        let onTotal = mean(on.map { sum($0, { $0.ocrMs }, from: 1) + sum($0, { $0.changeMs }, from: 1) + sum($0, { $0.mergeMs }, from: 1) })
+        let n = frameCount - 1
+        let tiles = off[0].tiles.dropFirst().reduce(0, +)
+        let offChars = off.map { $0.chars.dropFirst().reduce(0, +) }
+        let onChars = on.map { $0.chars.dropFirst().reduce(0, +) }
+
+        print("""
+        BENCH RESULT \(chunk)
+          region frames (excl. cold frame 0): \(n), tiles re-OCR'd total: \(tiles) of \(off[0].totalTiles)/frame
+          cold frame-0 OCR      OFF \(String(format: "%8.1f", offOCRcold)) ms   ON \(String(format: "%8.1f", onOCRcold)) ms   \(pct(offOCRcold, onOCRcold))
+          region OCR (sum)      OFF \(String(format: "%8.1f", offOCR)) ms   ON \(String(format: "%8.1f", onOCR)) ms   \(pct(offOCR, onOCR))
+          region OCR (per frame)OFF \(String(format: "%8.1f", offOCR / Double(n))) ms   ON \(String(format: "%8.1f", onOCR / Double(n))) ms
+          stage total (sum)     OFF \(String(format: "%8.1f", offTotal)) ms   ON \(String(format: "%8.1f", onTotal)) ms   \(pct(offTotal, onTotal))
+          chars recognised      OFF \(offChars)   ON \(onChars)
+          per-pass OCR sums     OFF \(off.map { Int(sum($0, { $0.ocrMs }, from: 1)) })   ON \(on.map { Int(sum($0, { $0.ocrMs }, from: 1)) })
+          per-pass tile counts  OFF \(off.map { $0.tiles.dropFirst().reduce(0, +) })   ON \(on.map { $0.tiles.dropFirst().reduce(0, +) })
+          per-frame tiles       \(Array(off[0].tiles.dropFirst()))
+          per-frame OCR ms OFF  \(Array(off[0].ocrMs.dropFirst()).map { Int($0) })
+          per-frame OCR ms ON   \(Array(on[0].ocrMs.dropFirst()).map { Int($0) })
+        \(searchTokenReport(off: off[0], on: on[0]))
+        """)
+    }
+
+
+    /// Search-token overlap between the two arms. Counts only -- never the tokens
+    /// themselves, which are real screen contents.
+    private static func searchTokenReport(off: PassResult, on: PassResult) -> String {
+        func tokens(_ texts: [String]) -> Set<String> {
+            var out: Set<String> = []
+            for text in texts {
+                for raw in text.split(whereSeparator: { $0.isWhitespace || $0.isNewline }) {
+                    let token = raw.lowercased().trimmingCharacters(
+                        in: CharacterSet.alphanumerics.inverted
+                    )
+                    if token.count >= 3 { out.insert(token) }
+                }
+            }
+            return out
+        }
+        let offTokens = tokens(Array(off.text.dropFirst()))
+        let onTokens = tokens(Array(on.text.dropFirst()))
+        let shared = offTokens.intersection(onTokens).count
+        func pct(_ part: Int, _ whole: Int) -> String {
+            whole == 0 ? "n/a" : String(format: "%.2f%%", Double(part) / Double(whole) * 100)
+        }
+        // Characterise the tokens each arm finds alone, without printing any of them.
+        // If correction is rewriting technical tokens into dictionary words, the
+        // OFF-only set should skew code-like (digits, punctuation, mixed case) and the
+        // ON-only set should skew plain lowercase alphabetic.
+        func shape(_ tokens: Set<String>, _ label: String) -> String {
+            guard !tokens.isEmpty else { return "            \(label): none" }
+            let count = Double(tokens.count)
+            let withDigit = tokens.filter { $0.contains(where: \.isNumber) }.count
+            let allAlpha = tokens.filter { $0.allSatisfy(\.isLetter) }.count
+            let meanLength = Double(tokens.reduce(0) { $0 + $1.count }) / count
+            return String(
+                format: "            %@: %d tokens, mean len %.1f, %.1f%% contain a digit, %.1f%% all-alphabetic",
+                label, tokens.count, meanLength,
+                Double(withDigit) / count * 100, Double(allAlpha) / count * 100
+            )
+        }
+        let offOnly = offTokens.subtracting(onTokens)
+        let onOnly = onTokens.subtracting(offTokens)
+        return """
+          search tokens         OFF \(offTokens.count) distinct   ON \(onTokens.count) distinct   shared \(shared)
+            of ON's tokens, OFF also finds  \(pct(shared, onTokens.count))  (missed \(onTokens.count - shared))
+            of OFF's tokens, ON also finds  \(pct(shared, offTokens.count))  (missed \(offTokens.count - shared))
+        \(shape(offTokens.intersection(onTokens), "shared  "))
+        \(shape(offOnly, "OFF-only"))
+        \(shape(onOnly, "ON-only "))
+        """
+    }
+
+    private static func pct(_ offValue: Double, _ onValue: Double) -> String {
+        guard onValue > 0 else { return "" }
+        return String(format: "(OFF is %.1f%% faster than ON)", (onValue - offValue) / onValue * 100)
+    }
+
+    // MARK: - Decode real captured frames to BGRA
+
+    private static func decodeFrames(url: URL, limit: Int) async throws -> [CapturedFrame] {
+        let asset = AVURLAsset(url: url)
+        let tracks = try await asset.loadTracks(withMediaType: .video)
+        guard let track = tracks.first else { return [] }
+        let reader = try AVAssetReader(asset: asset)
+        let output = AVAssetReaderTrackOutput(
+            track: track,
+            outputSettings: [kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA]
+        )
+        reader.add(output)
+        guard reader.startReading() else { return [] }
+        var frames: [CapturedFrame] = []
+        while frames.count < limit, let sample = output.copyNextSampleBuffer() {
+            guard let buffer = CMSampleBufferGetImageBuffer(sample) else { continue }
+            CVPixelBufferLockBaseAddress(buffer, .readOnly)
+            let width = CVPixelBufferGetWidth(buffer)
+            let height = CVPixelBufferGetHeight(buffer)
+            let bytesPerRow = CVPixelBufferGetBytesPerRow(buffer)
+            if let base = CVPixelBufferGetBaseAddress(buffer) {
+                let data = Data(bytes: base, count: bytesPerRow * height)
+                frames.append(CapturedFrame(
+                    timestamp: Date(),
+                    imageData: data,
+                    width: width,
+                    height: height,
+                    bytesPerRow: bytesPerRow,
+                    metadata: .empty
+                ))
+            }
+            CVPixelBufferUnlockBaseAddress(buffer, .readOnly)
+        }
+        reader.cancelReading()
+        return frames
+    }
+}

--- a/Shared/Models/Config.swift
+++ b/Shared/Models/Config.swift
@@ -313,18 +313,31 @@ public struct ProcessingConfig: Codable, Sendable {
     /// Hint to Vision to prefer background processing (lower resource usage)
     public let preferBackgroundProcessing: Bool
 
+    /// Whether Vision runs its language-correction pass over recognised text.
+    ///
+    /// Off by default because it is expensive and, for a searchable timeline, buys nothing
+    /// measurable. Measured on a 3440x1440 text-dense frame: full-frame recognition costs
+    /// 632.9 ms with correction versus 320.6 ms without (49.4% faster), and the region path
+    /// -- the one production actually uses -- costs 1778.4 ms versus 1283.0 ms (27.9% faster).
+    /// Search-token recall is identical either way (35/36 on code/terminal/URL content, 36/36
+    /// on prose), and correction actually recognises *less* text (3,859 vs 5,087 characters),
+    /// consistent with it discarding technical tokens it cannot map to dictionary words.
+    public let ocrLanguageCorrectionEnabled: Bool
+
     public init(
         accessibilityEnabled: Bool = true,
         ocrAccuracyLevel: OCRAccuracyLevel = .accurate,
         recognitionLanguages: [String] = ["en-US"],
         minimumConfidence: Float = 0.5,
-        preferBackgroundProcessing: Bool = false
+        preferBackgroundProcessing: Bool = false,
+        ocrLanguageCorrectionEnabled: Bool = false
     ) {
         self.accessibilityEnabled = accessibilityEnabled
         self.ocrAccuracyLevel = ocrAccuracyLevel
         self.recognitionLanguages = recognitionLanguages
         self.minimumConfidence = minimumConfidence
         self.preferBackgroundProcessing = preferBackgroundProcessing
+        self.ocrLanguageCorrectionEnabled = ocrLanguageCorrectionEnabled
     }
 
     public static let `default` = ProcessingConfig()

--- a/Shared/Models/Config.swift
+++ b/Shared/Models/Config.swift
@@ -315,13 +315,29 @@ public struct ProcessingConfig: Codable, Sendable {
 
     /// Whether Vision runs its language-correction pass over recognised text.
     ///
-    /// Off by default because it is expensive and, for a searchable timeline, buys nothing
-    /// measurable. Measured on a 3440x1440 text-dense frame: full-frame recognition costs
-    /// 632.9 ms with correction versus 320.6 ms without (49.4% faster), and the region path
-    /// -- the one production actually uses -- costs 1778.4 ms versus 1283.0 ms (27.9% faster).
-    /// Search-token recall is identical either way (35/36 on code/terminal/URL content, 36/36
-    /// on prose), and correction actually recognises *less* text (3,859 vs 5,087 characters),
-    /// consistent with it discarding technical tokens it cannot map to dictionary words.
+    /// Off by default because it doubles the cost of the region path, which is the one
+    /// production actually uses. Measured by `RegionOCRLanguageCorrectionBenchmark`,
+    /// which replays real captured frames through `recognizeTextRegionBased` with both
+    /// settings in OFF/ON/ON/OFF order so load drift cancels: over 156 paired region
+    /// frames from four 3440x1440 chunks, region OCR costs 42.6 s with correction off
+    /// versus 86.6 s with it on -- **50.2% cheaper** (per chunk 48.4/50.7/50.7/52.3%,
+    /// and 51.7/51.4/52.0/48.5% across two independent re-runs). The saving holds at
+    /// every changed-tile count, including the 51-200 tiles typical of interactive use
+    /// (50.3% and 49.1%), so it does not depend on the workload.
+    ///
+    /// An earlier synthetic benchmark put this at 27.9% and reported that recall was
+    /// identical and that correction recognised *less* text. Real frames contradict
+    /// both of those: correction recognises 1-2% *more* characters, and the two token
+    /// sets overlap only 68-76% -- in **both** directions. Correction is not a superset
+    /// or a subset, it is a different index. Off yields 6-12% more distinct search
+    /// tokens, and the tokens only it finds are longer (mean 7.9-8.4 vs 6.4-6.9 chars)
+    /// and less often plain alphabetic, which is what you would expect if correction
+    /// rewrites technical strings into dictionary words. That is the reason to keep it
+    /// off for a developer's timeline, but which index is *more accurate* was not
+    /// established -- doing so needs ground truth for what was on screen.
+    ///
+    /// Reversible without a rebuild:
+    /// `defaults write io.retrace.app retrace.ocr.languageCorrectionEnabled -bool YES`
     public let ocrLanguageCorrectionEnabled: Bool
 
     public init(


### PR DESCRIPTION
The region OCR path asks Vision for its language-correction pass on every frame, while the full-frame path already has it switched off. Turning it off on the region path too — the path production actually uses — **halves region OCR cost**.

## Measurement

`RegionOCRLanguageCorrectionBenchmark` (added here) replays **real captured frames** through the production `VisionOCR.recognizeTextRegionBased` entry point. It is paired — both arms see byte-identical frames — and runs the sequence OFF/ON/ON/OFF so any monotonic thermal or load drift cancels.

Over **156 paired region frames** from four 3440x1440 chunks spanning two different work sessions:

| | correction off | correction on |
|---|---|---|
| region OCR, total | 42.6 s | 86.6 s |

**50.2% cheaper.** Per chunk: 48.4 / 50.7 / 50.7 / 52.3%. Two independent re-runs: 51.7 / 51.4 and 52.0 / 48.5%.

Bucketed by changed-tile count it holds everywhere — 50.3% at 51–100 tiles, 49.1% at 101–200, which is the range interactive use actually sits in. So it is not an artifact of one workload.

The benchmark is opt-in (`RETRACE_BENCH_CHUNKS=…`), reads the given files read-only, and never prints recognised text — only aggregate counts — since real frames are real screen contents.

## On quality

I want to be straight about this rather than claim it is free.

Correction **on** recognises 1–2% *more* characters. The two token sets overlap only **68–76%, in both directions** — it is a different index, not a subset. Correction **off** yields 6–12% more distinct search tokens, and the tokens only it finds are longer (mean 7.9–8.4 vs 6.4–6.9 chars) and less often plain alphabetic, which is what you would expect if correction is rewriting technical strings into dictionary words. For a timeline full of code, paths and URLs that argues for off.

Which index is genuinely more *accurate* I did not establish — that needs ground truth for what was on screen, which I do not have. Given that, the change ships as a config flag defaulting to off, reversible without a rebuild:

```
defaults write io.retrace.app retrace.ocr.languageCorrectionEnabled -bool YES
```

If you would rather default it on and keep the flag, that is a one-line change and the perf note still documents the cost.

Relates to #38. Needs #42 to build the test targets.