### PR TITLE
fix(logging): stop test processes writing to the running app's log file

### DIFF
--- a/Shared/Logging.swift
+++ b/Shared/Logging.swift
@@ -64,8 +64,13 @@ public enum Log {
 
     // MARK: - Log File (for fast feedback diagnostics)
 
-    /// Path to the log file - persists across crashes
-    public static let logFilePath = NSHomeDirectory() + "/Library/Logs/Retrace/retrace.log"
+    /// Path to the log file - persists across crashes.
+    ///
+    /// Resolved the same way the writer resolves it, so readers (feedback diagnostics)
+    /// and the writer never disagree about which file is the log.
+    public static var logFilePath: String {
+        NSHomeDirectory() + "/Library/Logs/Retrace/" + LogFile.resolveLogFileName()
+    }
     /// Get recent logs from the log file (fast file read, no OSLogStore)
     public static func getRecentLogs(maxCount: Int = 200) -> [String] {
         LogFile.shared.readLastLines(count: maxCount)
@@ -402,7 +407,7 @@ private final class LogFile: @unchecked Sendable {
     /// `swift test` sets none of the usual `XCTest*` environment variables (verified,
     /// not assumed), so detect the loaded XCTest runtime instead. `RETRACE_LOG_FILE`
     /// overrides the choice outright.
-    private static func resolveLogFileName() -> String {
+    fileprivate static func resolveLogFileName() -> String {
         if let override = ProcessInfo.processInfo.environment["RETRACE_LOG_FILE"],
            !override.isEmpty {
             return override

--- a/Shared/Logging.swift
+++ b/Shared/Logging.swift
@@ -388,9 +388,31 @@ private final class LogFile: @unchecked Sendable {
     private var fileHandle: FileHandle?
     private let maxFileSize: Int64 = 50 * 1024 * 1024  // 50MB max, then rotate
 
+    /// Test processes log somewhere else entirely.
+    ///
+    /// Every process opens its own handle and calls `seekToEndOfFile()` exactly once,
+    /// then writes at its own advancing offset. Two writers therefore do not
+    /// interleave -- they overwrite each other's bytes, leaving a file whose
+    /// timestamps run out of order and whose records are shredded. They also share
+    /// the 50 MB rotation budget, and a full `swift test` run writes on the order of
+    /// a megabyte, so a testing session evicts the running app's diagnostics within
+    /// the hour. That log is the only record of what the app actually did, so tests
+    /// must not be able to destroy it.
+    ///
+    /// `swift test` sets none of the usual `XCTest*` environment variables (verified,
+    /// not assumed), so detect the loaded XCTest runtime instead. `RETRACE_LOG_FILE`
+    /// overrides the choice outright.
+    private static func resolveLogFileName() -> String {
+        if let override = ProcessInfo.processInfo.environment["RETRACE_LOG_FILE"],
+           !override.isEmpty {
+            return override
+        }
+        return NSClassFromString("XCTestCase") != nil ? "retrace-tests.log" : "retrace.log"
+    }
+
     private init() {
         let logDir = NSHomeDirectory() + "/Library/Logs/Retrace"
-        self.fileURL = URL(fileURLWithPath: logDir + "/retrace.log")
+        self.fileURL = URL(fileURLWithPath: logDir + "/" + Self.resolveLogFileName())
 
         // Create directory if needed
         try? FileManager.default.createDirectory(


### PR DESCRIPTION
Running `swift test` while Retrace is running destroys the app's log — silently, and in three separate ways. All three are observed, not theorised.

Every process opens its own handle to `~/Library/Logs/Retrace/retrace.log` and calls `seekToEndOfFile()` exactly **once**, then writes at its own advancing offset. Two writers therefore do not interleave, they **overwrite each other's bytes**. That is why that file carries out-of-order timestamps and shredded records.

They also share the 50 MB rotation budget, and rotation *renames* the file — so a rotation done by one process leaves every other process writing into a handle that now points at `retrace.old.log`.

What I measured on my own machine during a day of test runs:

- A testing session wrote **50 MB in 34 minutes**. The rotated-out file contained 54,631 `DatabaseManager` lines and **not one** of the app's 7,828 `COMPLETED frame` records — the app's entire OCR history for the day, evicted by test output.
- `lsof` showed the running app holding **`retrace.old.log`** open, having followed the inode a test process renamed.
- The app then logged **nothing at all for five minutes** while capturing 129 frames. Its file logging was simply dead, and stayed dead, with no error surfaced — every write goes through `try?`.

That log is the only record of what the app actually did. Tests should not be able to destroy it, so give them their own `retrace-tests.log`. `RETRACE_LOG_FILE` overrides the choice for anything else.

Detection is by loaded XCTest runtime rather than environment: `swift test` sets none of `XCTestConfigurationFilePath`, `XCTestSessionIdentifier` or `XCTestBundlePath`. I checked with a throwaway probe test rather than assuming, because the obvious guess is wrong.

Verified: one full suite run now writes 3,985,834 bytes to `retrace-tests.log` and exactly **0** bytes to `retrace.log`.

Note this cannot repair an already-running app, whose handle is already on the renamed inode; that needs a restart.