### PR TITLE
fix(logging): bound MemoryLedger's pending-write backlog

### DIFF
--- a/Processing/AGENTS.md
+++ b/Processing/AGENTS.md
@@ -35,6 +35,7 @@ Processing/
 └── Tests/
     ├── ExtractRequestInstrumentationTests.swift # Region tail aggregation and coordinator helper coverage
     ├── InPageURLMetadataResolutionTests.swift # In-page URL metadata retry and rewrite scheduling regression coverage
+    ├── MemoryLedgerPendingWriteBoundTests.swift # Ledger pending-write backlog cap and ordered-write coverage
     ├── OCRMemoryBackpressurePolicyTests.swift # OCR memory backpressure threshold/default coverage
     ├── PhraseLevelRedactionTests.swift        # Manual + automatic OCR phrase-level redaction coverage
     ├── RewriteRetryPolicyTests.swift          # Bounded automatic rewrite retry coverage

--- a/Processing/ExtractMemoryInstrumentation.swift
+++ b/Processing/ExtractMemoryInstrumentation.swift
@@ -360,7 +360,12 @@ enum ProcessingExtractMemoryLedger {
 
     static func synchronizedLedgerSnapshot() async -> MemoryLedger.Snapshot {
         let processSnapshot = currentProcessMemorySnapshotForLedger()
-        MemoryLedger.setProcessSnapshot(
+        // Ordered, not fire-and-forget: this function's contract is that the process
+        // snapshot is applied *before* the ledger is read, and the fire-and-forget
+        // path may refuse a write once its backlog is saturated -- which would leave
+        // the snapshot below reading a stale footprint precisely when the process is
+        // under the most memory pressure.
+        await MemoryLedger.setProcessSnapshotOrdered(
             footprintBytes: processSnapshot?.physFootprintBytes,
             residentBytes: processSnapshot?.residentBytes,
             internalBytes: processSnapshot?.internalBytes,

--- a/Processing/OCR/VisionOCRResidualSupport.swift
+++ b/Processing/OCR/VisionOCRResidualSupport.swift
@@ -136,7 +136,12 @@ extension VisionOCR {
 
     static func synchronizedLedgerSnapshot() async -> MemoryLedger.Snapshot {
         let processSnapshot = ProcessingMemoryDiagnostics.currentProcessMemorySnapshot()
-        MemoryLedger.setProcessSnapshot(
+        // Ordered, not fire-and-forget: this function's contract is that the process
+        // snapshot is applied *before* the ledger is read, and the fire-and-forget path
+        // may refuse a write once its backlog is saturated -- which would leave the
+        // snapshot below reading a stale footprint precisely when the process is under
+        // the most memory pressure. Mirrors ProcessingExtractMemoryLedger's copy.
+        await MemoryLedger.setProcessSnapshotOrdered(
             footprintBytes: processSnapshot?.physFootprintBytes,
             residentBytes: processSnapshot?.residentBytes,
             internalBytes: processSnapshot?.internalBytes,

--- a/Processing/Tests/MemoryLedgerPendingWriteBoundTests.swift
+++ b/Processing/Tests/MemoryLedgerPendingWriteBoundTests.swift
@@ -1,0 +1,95 @@
+import XCTest
+import Shared
+
+/// `MemoryLedger` chains every pending write onto its predecessor, so each one keeps a
+/// live `Task` alive that retains the one before it. Before the fire-and-forget entry
+/// points were capped, a writer that outran the drain grew that chain without bound --
+/// an unthrottled loop in `OCRStageMemoryLedgerCostTests` killed the test process with
+/// signal 10, and `flushPendingUpdates()` had to await the whole backlog to return.
+final class MemoryLedgerPendingWriteBoundTests: XCTestCase {
+
+    private let tagPrefix = "test.memoryLedger.pendingWriteBound"
+
+    override func tearDown() async throws {
+        await MemoryLedger.flushPendingUpdates()
+        try await super.tearDown()
+    }
+
+    func testFireAndForgetFloodStaysWithinBacklogLimit() async {
+        let limit = MemoryLedger.pendingWriteDiagnostics.limit
+        let droppedBefore = MemoryLedger.pendingWriteDiagnostics.dropped
+
+        // Far more writes than the drain can retire while the loop runs. Unbounded,
+        // this is the shape that used to kill the process.
+        var maxObservedDepth = 0
+        for index in 0..<20_000 {
+            MemoryLedger.set(
+                tag: "\(tagPrefix).flood",
+                bytes: Int64(index),
+                function: "test.memoryLedger",
+                kind: "telemetry"
+            )
+            maxObservedDepth = max(maxObservedDepth, MemoryLedger.pendingWriteDiagnostics.depth)
+        }
+
+        XCTAssertLessThanOrEqual(
+            maxObservedDepth,
+            limit,
+            "Pending-write backlog grew past its cap; the chain is unbounded again."
+        )
+        XCTAssertGreaterThan(
+            MemoryLedger.pendingWriteDiagnostics.dropped,
+            droppedBefore,
+            "20,000 fire-and-forget writes outran the drain but nothing was dropped, "
+                + "so this test is no longer exercising the cap."
+        )
+
+        // The whole point of the cap: flushing cannot be left awaiting an unbounded
+        // chain. Generous bound -- this is a liveness check, not a timing assertion.
+        let start = Date()
+        await MemoryLedger.flushPendingUpdates()
+        XCTAssertLessThan(Date().timeIntervalSince(start), 60)
+        XCTAssertEqual(MemoryLedger.pendingWriteDiagnostics.depth, 0)
+
+        await MemoryLedger.removeOrdered(tag: "\(tagPrefix).flood")
+    }
+
+    func testAcceptedWritesStillLandAndOrderedWritesAreNeverDropped() async {
+        let tag = "\(tagPrefix).ordered"
+
+        // Saturate the backlog first, so the ordered write below is issued precisely
+        // when the fire-and-forget path is refusing work.
+        for index in 0..<20_000 {
+            MemoryLedger.set(
+                tag: "\(tagPrefix).noise",
+                bytes: Int64(index),
+                function: "test.memoryLedger",
+                kind: "telemetry"
+            )
+        }
+
+        let droppedBeforeOrdered = MemoryLedger.pendingWriteDiagnostics.dropped
+        await MemoryLedger.setOrdered(
+            tag: tag,
+            bytes: 4_096,
+            function: "test.memoryLedger",
+            kind: "telemetry"
+        )
+        XCTAssertEqual(
+            MemoryLedger.pendingWriteDiagnostics.dropped,
+            droppedBeforeOrdered,
+            "An ordered write was dropped; only fire-and-forget writes may be refused."
+        )
+
+        let snapshot = await MemoryLedger.snapshot(waitForPendingUpdates: true)
+        let ordered = snapshot.components.first { $0.tag == tag }
+        XCTAssertEqual(ordered?.bytes, 4_096, "The ordered write never reached the store.")
+
+        // A dropped `set` must not stop later writes to the same tag from landing.
+        let noise = snapshot.components.first { $0.tag == "\(tagPrefix).noise" }
+        XCTAssertNotNil(noise, "Every fire-and-forget write was dropped, not just the excess.")
+
+        await MemoryLedger.removeOrdered(tag: tag)
+        await MemoryLedger.removeOrdered(tag: "\(tagPrefix).noise")
+    }
+}

--- a/Shared/Logging.swift
+++ b/Shared/Logging.swift
@@ -514,6 +514,23 @@ public enum MemoryLedger {
     private static let store = MemoryLedgerStore()
     private static let pendingWriteLock = NSLock()
     private static var pendingWriteTail: Task<Void, Never>?
+    /// Enqueued writes that have not finished yet. Guarded by `pendingWriteLock`.
+    private static var pendingWriteDepth = 0
+    /// Writes refused because the backlog was already at `pendingWriteDepthLimit`.
+    private static var pendingWriteDropCount = 0
+    /// Backlog depth past which fire-and-forget writes are refused.
+    ///
+    /// Every write chains itself onto its predecessor, so each pending write keeps a
+    /// live `Task` alive that retains the one before it. A producer that outruns the
+    /// drain therefore grows an unbounded chain, and `flushPendingUpdates()` -- which
+    /// awaits the tail -- has to wait for all of it. An unthrottled writer loop grew
+    /// that chain until the test process died with signal 10.
+    ///
+    /// Ordered writes cannot run away, because their caller awaits each one before
+    /// issuing the next, so the cap applies only to the fire-and-forget entry points.
+    /// Production sits a handful of writes deep; this only engages on pathological
+    /// write rates, where dropping telemetry beats killing the process.
+    private static let pendingWriteDepthLimit = 256
     private static let summaryLoggingDefaultsKey = "retrace.debug.memoryLedgerSummaryLoggingEnabled"
 
     public struct ResidualEpoch: Sendable {
@@ -600,21 +617,80 @@ public enum MemoryLedger {
         _ = await pendingWriteSnapshot()?.result
     }
 
+    /// Backlog depth, writes dropped because the backlog was full, and the cap itself.
+    public static var pendingWriteDiagnostics: (depth: Int, dropped: Int, limit: Int) {
+        pendingWriteLock.lock()
+        defer { pendingWriteLock.unlock() }
+        return (pendingWriteDepth, pendingWriteDropCount, pendingWriteDepthLimit)
+    }
+
+    /// Chain `operation` onto the current tail. The caller must hold `pendingWriteLock`.
     @discardableResult
-    private static func enqueuePendingWrite(
+    private static func appendPendingWriteLocked(
         _ operation: @escaping @Sendable () async -> Void
     ) -> Task<Void, Never> {
-        pendingWriteLock.lock()
         let previousTail = pendingWriteTail
+        pendingWriteDepth += 1
         let task = Task(priority: .utility) {
             if let previousTail {
                 _ = await previousTail.result
             }
             await operation()
+            retirePendingWrite()
         }
         pendingWriteTail = task
-        pendingWriteLock.unlock()
         return task
+    }
+
+    /// Account for a finished write. Synchronous because `NSLock` may not be taken
+    /// from an async context.
+    private static func retirePendingWrite() {
+        pendingWriteLock.lock()
+        pendingWriteDepth -= 1
+        // Nobody can be waiting on this chain any more, so stop retaining its tail.
+        if pendingWriteDepth == 0 {
+            pendingWriteTail = nil
+        }
+        pendingWriteLock.unlock()
+    }
+
+    /// Enqueue a write whose completion the caller awaits.
+    ///
+    /// Uncapped on purpose: an awaiting caller cannot outrun the drain, so the depth
+    /// these contribute is bounded by the number of concurrent callers.
+    @discardableResult
+    private static func enqueuePendingWrite(
+        _ operation: @escaping @Sendable () async -> Void
+    ) -> Task<Void, Never> {
+        pendingWriteLock.lock()
+        defer { pendingWriteLock.unlock() }
+        return appendPendingWriteLocked(operation)
+    }
+
+    /// Enqueue a fire-and-forget write, refusing it once the backlog is saturated.
+    ///
+    /// These entry points are not `async`, so they have no way to apply backpressure;
+    /// refusing a telemetry write is the only bound available to them.
+    private static func enqueueDroppablePendingWrite(
+        _ operation: @escaping @Sendable () async -> Void
+    ) {
+        pendingWriteLock.lock()
+        guard pendingWriteDepth < pendingWriteDepthLimit else {
+            pendingWriteDropCount += 1
+            let dropped = pendingWriteDropCount
+            pendingWriteLock.unlock()
+            // Report on crossing each multiple of the limit, so a saturated ledger is
+            // visible without the report itself becoming the flood.
+            if dropped.isMultiple(of: pendingWriteDepthLimit) {
+                Log.warning(
+                    "[MemoryLedger] Dropped \(dropped) telemetry writes; pending-write backlog is at its \(pendingWriteDepthLimit) limit",
+                    category: .app
+                )
+            }
+            return
+        }
+        appendPendingWriteLocked(operation)
+        pendingWriteLock.unlock()
     }
 
     private static func pendingWriteSnapshot() -> Task<Void, Never>? {
@@ -653,7 +729,7 @@ public enum MemoryLedger {
         countsTowardTrackedMemory: Bool = true
     ) {
         guard !tag.isEmpty else { return }
-        enqueuePendingWrite {
+        enqueueDroppablePendingWrite {
             await store.set(
                 tag: tag,
                 bytes: bytes,
@@ -697,6 +773,11 @@ public enum MemoryLedger {
     }
 
     /// Remove a component from the ledger.
+    ///
+    /// Deliberately not droppable. A dropped `set` self-corrects on the next write of
+    /// the same tag, but a dropped `remove` would strand a component in the ledger
+    /// permanently and overstate tracked memory from then on. Removes are driven by
+    /// teardown rather than per-frame work, so they cannot be the runaway producer.
     public static func remove(tag: String) {
         guard !tag.isEmpty else { return }
         enqueuePendingWrite {
@@ -719,7 +800,7 @@ public enum MemoryLedger {
         internalBytes: UInt64?,
         compressedBytes: UInt64?
     ) {
-        enqueuePendingWrite {
+        enqueueDroppablePendingWrite {
             await store.setProcessSnapshot(
                 footprintBytes: footprintBytes,
                 residentBytes: residentBytes,
@@ -753,7 +834,7 @@ public enum MemoryLedger {
         minIntervalSeconds: TimeInterval = 30,
         force: Bool = false
     ) {
-        enqueuePendingWrite {
+        enqueueDroppablePendingWrite {
             await store.emitSummaryIfNeeded(
                 reason: reason,
                 category: category,


### PR DESCRIPTION
`MemoryLedger.enqueuePendingWrite` chains every write onto its predecessor, so each pending write keeps a live `Task` alive that retains the one before it. A producer that outruns the drain grows that chain without bound — and `flushPendingUpdates()`, which awaits the tail, then has to wait for the entire backlog before it can return.

An unthrottled writer loop kills the process outright.

## Fix

Ordered writes cannot run away, because their caller awaits each one before issuing the next, so the cap applies only to the fire-and-forget entry points that have no way to apply backpressure. `set`, `setProcessSnapshot` and `emitSummary` now refuse work past a 256-deep backlog and count the refusals, reporting on each multiple of the limit so a saturated ledger is visible without the report itself becoming the flood.

`remove()` deliberately stays uncapped: a dropped `set` self-corrects on the next write of the same tag, but a dropped `remove` would strand a component in the ledger permanently and overstate tracked memory from then on — and removes are driven by teardown, not per-frame work, so they cannot be the runaway producer.

Second commit: `synchronizedLedgerSnapshot()` exists to guarantee the process snapshot is applied *before* the ledger is read. It got that for free while every write was unbounded, so it moves to the ordered variant — otherwise a refused write would leave it reading a stale footprint exactly when the process is under the most memory pressure.

## Verified

By running the new tests with the cap raised to `Int.max`:

```
cap = Int.max   20,000 fire-and-forget writes   process dies, signal code 10
cap = 256       20,000 fire-and-forget writes   2 tests pass in 0.044s
```

The tests pin both halves: the backlog never exceeds the cap and refusals are actually counted, while an ordered write issued against a saturated backlog is never dropped and still reaches the store.

In normal operation the cap never engages — my running instance records **zero** drops. This is a backstop, not a limiter.

Needs #42 to build the test targets.